### PR TITLE
Added GitHub stars task

### DIFF
--- a/cogs/stars.py
+++ b/cogs/stars.py
@@ -1,0 +1,41 @@
+import aiohttp
+from nextcord.ext import commands
+from nextcord.ext.tasks import loop
+
+
+class GitHubStars(commands.Cog):
+    """Run a task loop to update a channel with the current stars for nextcord/nextcord"""
+
+    STARS_CHANNEL_ID = 884441198520045570
+
+    def __init__(self, bot: commands.Bot):
+        self.__bot = bot
+        self.update_stars.start()
+
+    async def get_stars(self, repo: str) -> int:
+        """Get number of GitHub stars for a given repo in the form 'owner/repository'"""
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f'https://api.github.com/repos/{repo}') as resp:
+                data = await resp.json()
+                return int(data['stargazers_count'])
+
+    @loop(minutes=15)
+    async def update_stars(self):
+        """Loop to check and update stars"""
+        channel_name = "🌟 {}".format(await self.get_stars('nextcord/nextcord'))
+        # update channel name if it has changed
+        if self.__channel.name != channel_name:
+            await self.__channel.edit(name=channel_name)
+
+    @update_stars.before_loop
+    async def before_update_stars(self):
+        """Before the loop starts, get the channel"""
+        await self.__bot.wait_until_ready()
+        self.__channel = self.__bot.get_channel(self.STARS_CHANNEL_ID)
+
+    def cog_unload(self):
+        self.update_stars.cancel()
+
+
+def setup(bot):
+    bot.add_cog(GitHubStars(bot))


### PR DESCRIPTION
In honor of 300 stars on GitHub, why not make a task that automates updating the star count channel?

![image](https://user-images.githubusercontent.com/20955511/136119633-c6fb16e3-3ac4-4801-9bf4-b626006031da.png)

Since it's pretty simple to do, I've set up a simple task that will check the number of stars every 15 minutes and update the channel name if it has changed.

![image](https://user-images.githubusercontent.com/20955511/136119781-184d2c80-acb3-4805-99b2-f0b29469afd6.png)
