### PR TITLE
Added guidelines for asking for help

### DIFF
--- a/assets/helpguide.txt
+++ b/assets/helpguide.txt
@@ -1,4 +1,4 @@
-**When asking for help, we ask that you please follow these guidelines:**
+:scroll:   **When asking for help, we ask that you please follow these guidelines:**
 
 **1. Please include your error message!** (if relevant)
 If your question is regarding your code not working, error messages assist the helpers in narrowing down the cause of the issue (what line it's on, what module is causing it, etc.). Not including any errors, tracebacks, etc. can slow things down considerably.
@@ -18,4 +18,4 @@ While it's fine to ask multiple questions for the same issue _or_ multiple issue
 
 **6. Please let us know your Python skill level!**
 While this is technically not _required_, it's good for the helpers to know if you're new to Python, as it lets them know how deep they need to explain something, and it may affect the help that they provide.
-Additionally, the helpers _may_ ask you to brush up on your Python basics so that you can understand the help that they provide you. Please don't take this personally, as Nextcord is a complex library and Discord bot projects aren't simple undertakings, so a solid knowledge oif Python's basics is needed in order to understand Nextcord and the help that we provide.
+Additionally, the helpers _may_ ask you to brush up on your Python basics so that you can understand the help that they provide you. Please don't take this personally, as Nextcord is a complex library and Discord bot projects aren't simple undertakings, so a solid knowledge of Python's basics is needed in order to understand Nextcord and the help that we provide.

--- a/assets/helpguide.txt
+++ b/assets/helpguide.txt
@@ -6,12 +6,11 @@ If your question is regarding your code not working, error messages assist the h
 **2. If you don't get an error message, please explain further!**
 Saying that your code throws _no_ error messages is still helpful, but the helpers still need more information to  understand the issue you're having. For example, if your code is meant to execute a specific line of code but it does not, or you expect your code to show one thing but it instead shows something different or weird-looking, let us know!
 
-**3. Show your code with mystb.in whevever you can!**
-For most issues, the helpers need to see your code (or at least a small snippet of the relevant code). Please show this where it's relevant to help speed up the support process.
-Additionally, please upload your large chunks of code to https://mystb.in/ instead of uploading a file or sending a code block on Discord. Some helpers use small screens (i.e. mobile devices) that have trouble accurately showing long lines of code.
+**3. Show your code with mystb.in!**
+In order to give accurate assistance, the helpers need to see your code (or at least a small snippet of the relevant code). Please upload your code to [mystb.in](https://mystb.in/) to help speed up the support process. We ask that you specifically upload your code to [mystb.in](https://mystb.in/) instead of uploading a file or sending a code block on Discord because some helpers may be using a small screen (i.e. mobile devices) that has trouble accurately showing long lines of code.
 
 **4. Try some simple debugging!**
-If you're having trouble finding where the issue lies, one thing you can try is placing `print()` statements at a few points in your code. When you see text printed in the terminal, you'll know whether or not the particular line that `print()` is on is reached or not. Additionally, try `print`ing out some variables and/or their types (using `type(varname)`) to figure out where the issue could be occurring.
+If you're having trouble finding where the issue lies, one thing you can try is placing `print()` or `breakpoint()` statements at a few points in your code to see if a certain line is reached. Try priting out variables, the type of certain variables, etc. [This relevant guide from Real Python is very helpful](https://realpython.com/lessons/print-and-breakpoint/).
 
 **5. Keep issues to a thread!**
 While it's fine to ask multiple questions for the same issue _or_ multiple issues that stem from the first issue (i.e. this is fixed, but now this is happening), we prefer **each thread to be kept to one issue at a time.** This makes it easier for the helpers to keep track of what you need help with.

--- a/assets/helpguide.txt
+++ b/assets/helpguide.txt
@@ -10,11 +10,4 @@ Saying that your code throws _no_ error messages is still helpful, but the helpe
 In order to give accurate assistance, the helpers need to see your code (or at least a small snippet of the relevant code). Please upload your code to [mystb.in](https://mystb.in/) to help speed up the support process. We ask that you specifically upload your code to [mystb.in](https://mystb.in/) instead of uploading a file or sending a code block on Discord because some helpers may be using a small screen (i.e. mobile devices) that has trouble accurately showing long lines of code.
 
 **4. Try some simple debugging!**
-If you're having trouble finding where the issue lies, one thing you can try is placing `print()` or `breakpoint()` statements at a few points in your code to see if a certain line is reached. Try priting out variables, the type of certain variables, etc. [This relevant guide from Real Python is very helpful](https://realpython.com/lessons/print-and-breakpoint/).
-
-**5. Keep issues to a thread!**
-While it's fine to ask multiple questions for the same issue _or_ multiple issues that stem from the first issue (i.e. this is fixed, but now this is happening), we prefer **each thread to be kept to one issue at a time.** This makes it easier for the helpers to keep track of what you need help with.
-
-**6. Please let us know your Python skill level!**
-While this is technically not _required_, it's good for the helpers to know if you're new to Python, as it lets them know how deep they need to explain something, and it may affect the help that they provide.
-Additionally, the helpers _may_ ask you to brush up on your Python basics so that you can understand the help that they provide you. Please don't take this personally, as Nextcord is a complex library and Discord bot projects aren't simple undertakings, so a solid knowledge of Python's basics is needed in order to understand Nextcord and the help that we provide.
+If you're having trouble finding where the issue lies, one thing you can try is placing `print()` or `breakpoint()` statements at a few points in your code to see if a certain line is reached. If this doesn't help you fix the issue, it'll assist you in asking more specific questions to the helpers - [this relevant guide from Real Python is very helpful](https://realpython.com/lessons/print-and-breakpoint/).

--- a/assets/helpguide.txt
+++ b/assets/helpguide.txt
@@ -1,0 +1,21 @@
+**When asking for help, we ask that you please follow these guidelines:**
+
+**1. Please include your error message!** (if relevant)
+If your question is regarding your code not working, error messages assist the helpers in narrowing down the cause of the issue (what line it's on, what module is causing it, etc.). Not including any errors, tracebacks, etc. can slow things down considerably.
+
+**2. If you don't get an error message, please explain further!**
+Saying that your code throws _no_ error messages is still helpful, but the helpers still need more information to  understand the issue you're having. For example, if your code is meant to execute a specific line of code but it does not, or you expect your code to show one thing but it instead shows something different or weird-looking, let us know!
+
+**3. Show your code with mystb.in whevever you can!**
+For most issues, the helpers need to see your code (or at least a small snippet of the relevant code). Please show this where it's relevant to help speed up the support process.
+Additionally, please upload your large chunks of code to https://mystb.in/ instead of uploading a file or sending a code block on Discord. Some helpers use small screens (i.e. mobile devices) that have trouble accurately showing long lines of code.
+
+**4. Try some simple debugging!**
+If you're having trouble finding where the issue lies, one thing you can try is placing `print()` statements at a few points in your code. When you see text printed in the terminal, you'll know whether or not the particular line that `print()` is on is reached or not. Additionally, try `print`ing out some variables and/or their types (using `type(varname)`) to figure out where the issue could be occurring.
+
+**5. Keep issues to a thread!**
+While it's fine to ask multiple questions for the same issue _or_ multiple issues that stem from the first issue (i.e. this is fixed, but now this is happening), we prefer **each thread to be kept to one issue at a time.** This makes it easier for the helpers to keep track of what you need help with.
+
+**6. Please let us know your Python skill level!**
+While this is technically not _required_, it's good for the helpers to know if you're new to Python, as it lets them know how deep they need to explain something, and it may affect the help that they provide.
+Additionally, the helpers _may_ ask you to brush up on your Python basics so that you can understand the help that they provide you. Please don't take this personally, as Nextcord is a complex library and Discord bot projects aren't simple undertakings, so a solid knowledge oif Python's basics is needed in order to understand Nextcord and the help that we provide.

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -140,10 +140,10 @@ class ThreadCloseView(ui.View):
         if not self._thread_author:
             await self._get_thread_author(interaction.channel)  # type: ignore
 
-        await interaction.channel.send(
-            content = "This thread has now been closed. "
-                      "Please create another thread if you wish to ask another question."
-        )
+        embed_reply = Embed(title="This thread has now been closed",
+                            description="If your question has not been answered or your issue not resolved, we suggest taking a look at [Python's Guide to Asking Good Questions](https://www.pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/) to get more effective help.",
+                            colour=Colour.dark_theme())
+        await interaction.channel.send(embed=embed_reply)
         button.disabled = True
         await interaction.message.edit(view = self)
         await interaction.channel.edit(locked = True, archived = True)
@@ -215,8 +215,10 @@ class HelpCog(commands.Cog):
 
         thread_author = await get_thread_author(ctx.channel)
         if thread_author.id == ctx.author.id or ctx.author.get_role(HELPER_ROLE_ID):
-            await ctx.send(
-                "This thread has now been closed. Please create another thread if you wish to ask another question.")
+            embed_reply = Embed(title="This thread has now been closed",
+                                description="If your question has not been answered or your issue not resolved, we suggest taking a look at [Python's Guide to Asking Good Questions](https://www.pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/) to get more effective help.",
+                                colour=Colour.dark_theme())
+            await ctx.send(embed=embed_reply)
             await ctx.channel.edit(locked = True, archived = True)
             await ctx.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
                 f"Help thread {ctx.channel.name} (created by {thread_author.name}) has been closed.")

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -205,7 +205,7 @@ class HelpCog(commands.Cog):
     @commands.is_owner()
     async def help_menu(self, ctx):
         for section in split_txtfile("helpguide.txt"):
-            await ctx.send(section)
+            await ctx.send(embed=Embed(description=section))
         await ctx.send("**:white_check_mark:  If you've read the guidelines above, click a button to create a help thread!**", view = HelpView())
 
     @commands.command()

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,4 +1,5 @@
 from typing import Dict, NamedTuple, Optional
+from .utils.split_txtfile import split_txtfile
 
 from nextcord.ext import commands
 from nextcord import (
@@ -203,7 +204,9 @@ class HelpCog(commands.Cog):
     @commands.command()
     @commands.is_owner()
     async def help_menu(self, ctx):
-        await ctx.send("Click a button to create a help thread!", view = HelpView())
+        for section in split_txtfile("helpguide.txt"):
+            await ctx.send(section)
+        await ctx.send("**:white_check_mark:  If you've read the guidelines above, click a button to create a help thread!**", view = HelpView())
 
     @commands.command()
     async def close(self, ctx):

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -141,7 +141,10 @@ class ThreadCloseView(ui.View):
             await self._get_thread_author(interaction.channel)  # type: ignore
 
         embed_reply = Embed(title="This thread has now been closed",
-                            description="If your question has not been answered or your issue not resolved, we suggest taking a look at [Python's Guide to Asking Good Questions](https://www.pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/) to get more effective help.",
+                            description="If your question has not been answered or your issue not "
+                                        "resolved, we suggest taking a look at [Python's Guide to "
+                                        "Asking Good Questions](https://www.pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/) "
+                                        "to get more effective help.",
                             colour=Colour.dark_theme())
         await interaction.channel.send(embed=embed_reply)
         button.disabled = True
@@ -206,7 +209,9 @@ class HelpCog(commands.Cog):
     async def help_menu(self, ctx):
         for section in split_txtfile("helpguide.txt"):
             await ctx.send(embed=Embed(description=section))
-        await ctx.send("**:white_check_mark:  If you've read the guidelines above, click a button to create a help thread!**", view = HelpView())
+        await ctx.send("**:white_check_mark:  If you've read the guidelines "
+                       "above, click a button to create a help thread!**",
+                       view = HelpView())
 
     @commands.command()
     async def close(self, ctx):
@@ -216,7 +221,10 @@ class HelpCog(commands.Cog):
         thread_author = await get_thread_author(ctx.channel)
         if thread_author.id == ctx.author.id or ctx.author.get_role(HELPER_ROLE_ID):
             embed_reply = Embed(title="This thread has now been closed",
-                                description="If your question has not been answered or your issue not resolved, we suggest taking a look at [Python's Guide to Asking Good Questions](https://www.pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/) to get more effective help.",
+                                description="If your question has not been answered or your issue not "
+                                            "resolved, we suggest taking a look at [Python's Guide to "
+                                            "Asking Good Questions](https://www.pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/) "
+                                            "to get more effective help.",
                                 colour=Colour.dark_theme())
             await ctx.send(embed=embed_reply)
             await ctx.channel.edit(locked = True, archived = True)

--- a/cogs/utils/split_txtfile.py
+++ b/cogs/utils/split_txtfile.py
@@ -1,0 +1,29 @@
+import os
+
+def split_txtfile(in_filename: str, chunk_len=2000) -> list:
+    """Takes a long plaintext file from the assets directory and splits it up
+    into 2000 character-long chunks to be sent over Discord and stay under the
+    character limit.
+
+    """
+    in_file_fullpath = os.path.join(os.getcwd(), "assets", in_filename)
+    all_chunks = []  # Each item is a <2000-character-long chunk of the infile.
+    current_chunk = ""  #  Store temp chunks here before adding to the above.
+    
+    with open(in_file_fullpath) as in_file:
+        for line in in_file:
+            # Before we concatenate the current chunk and the current line, we
+            # need to check if the resulting chunk is over 2000 chars long.
+            # If so, add that chunk to the list of chunks and start a brand new
+            # chunk to add to.
+            if len(current_chunk + line) >= 2000:
+                all_chunks.append(current_chunk)
+                current_chunk = ""
+            current_chunk += line
+        
+        # Once we finish iterating over each line in the input file, the last
+        # chunk is probably gonna be under 2000 chars and therefore won't be
+        # added to the chunk list. We have to add it here in case that happens.
+        all_chunks.append(current_chunk)
+    return all_chunks
+

--- a/cogs/utils/split_txtfile.py
+++ b/cogs/utils/split_txtfile.py
@@ -1,28 +1,27 @@
 import os
 
-def split_txtfile(in_filename: str, chunk_len=2000) -> list:
+def split_txtfile(in_filename: str, chunk_len=4000) -> list:
     """Takes a long plaintext file from the assets directory and splits it up
-    into 2000 character-long chunks to be sent over Discord and stay under the
-    character limit.
-
+    into 4000 character-long chunks to be sent over Discord and stay under the
+    embed content character limit (which is actually 4096 but shhh).
     """
     in_file_fullpath = os.path.join(os.getcwd(), "assets", in_filename)
-    all_chunks = []  # Each item is a <2000-character-long chunk of the infile.
+    all_chunks = []  # Each item is a <4000-character-long chunk of the infile.
     current_chunk = ""  #  Store temp chunks here before adding to the above.
     
     with open(in_file_fullpath) as in_file:
         for line in in_file:
             # Before we concatenate the current chunk and the current line, we
-            # need to check if the resulting chunk is over 2000 chars long.
+            # need to check if the resulting chunk is over 4000 chars long.
             # If so, add that chunk to the list of chunks and start a brand new
             # chunk to add to.
-            if len(current_chunk + line) >= 2000:
+            if len(current_chunk + line) >= chunk_len:
                 all_chunks.append(current_chunk)
                 current_chunk = ""
             current_chunk += line
         
         # Once we finish iterating over each line in the input file, the last
-        # chunk is probably gonna be under 2000 chars and therefore won't be
+        # chunk is probably gonna be under 4000 chars and therefore won't be
         # added to the chunk list. We have to add it here in case that happens.
         all_chunks.append(current_chunk)
     return all_chunks


### PR DESCRIPTION
- When a new help menu is created with `=help_menu`, a message containing guidelines on how to appropriately and effectively ask for help is included as well as the buttons.
- The guidelines are placed above the buttons, forcing the user to read (or at least scroll past) the guidelines before opening a new help thread.
- Compartmentalised the contents of the help message into a .txt file to allow for easier editing in the future if any guideline changes are needed down the line.
- Given that Discord has a 2000-character limit on messages sent by users _and_ bots, `split_txtfile()` will split the text file into adequately-sized chunks that can then be sent in multiple messages, one after the other.