### PR TITLE
Fix for issue #35

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ async def on_command_error(ctx, error):
     elif isinstance(error, nextcord.NotFound) and "Unknown interaction" in str(error):
         return
     else:
-        await ctx.channel.send("This command raised an exception: " + str(type(error) + ":" + str(error)))
+        await ctx.channel.send(f"This command raised an exception: `{type(error)}:{str(error)}`")
 
 
 @bot.listen()


### PR DESCRIPTION
Following on from issue #5, I've changed the `on_command_error` code so that it typecasts the `type` as a string _before_ combining it with the other string, like such:
https://github.com/squigjess/previous/blob/48b4088eaa1dd0a3b12a0249fd3ac6746116b4e3/main.py#L35