### PR TITLE
feat(rtfm): Added menus and ipc rtfm subcommands

### DIFF
--- a/cogs/rtfm.py
+++ b/cogs/rtfm.py
@@ -459,8 +459,12 @@ class Rtfm(commands.Cog):
             key = name if dispname == "-" else dispname
             prefix = f"{subdirective}:" if domain == "std" else ""
 
-            if projname == "nextcord":
-                key = key.replace("nextcord.ext.commands.", "").replace("nextcord.", "")
+            key = (
+                key.replace("nextcord.ext.commands.", "")
+                .replace("nextcord.ext.menus.", "")
+                .replace("nextcord.ext.ipc.", "")
+                .replace("nextcord.", "")
+            )
 
             result[f"{prefix}{key}"] = os.path.join(url, location)
 
@@ -481,8 +485,10 @@ class Rtfm(commands.Cog):
 
     async def do_rtfm(self, ctx, key, obj):
         page_types = {
-            'python': 'https://docs.python.org/3',
             'master': 'https://nextcord.readthedocs.io/en/latest',
+            'menus': 'https://nextcord-ext-menus.readthedocs.io/en/latest',
+            'ipc': 'https://nextcord-ext-ipc.readthedocs.io/en/latest',
+            'python': 'https://docs.python.org/3',
         }
 
         if obj is None:
@@ -527,6 +533,14 @@ class Rtfm(commands.Cog):
     @commands.group(name="rtfm", help="python docs", aliases=["rtfd"], invoke_without_command=True)
     async def rtfm_group(self, ctx: commands.Context, *, obj: str = None):
         await self.do_rtfm(ctx, "master", obj)
+
+    @rtfm_group.command(name="menus")
+    async def rtfm_menus_cmd(self, ctx: commands.Context, *, obj: str = None):
+        await self.do_rtfm(ctx, "menus", obj)
+
+    @rtfm_group.command(name="ipc")
+    async def rtfm_ipc_cmd(self, ctx: commands.Context, *, obj: str = None):
+        await self.do_rtfm(ctx, "ipc", obj)
 
     @rtfm_group.command(name="python", aliases=["py"])
     async def rtfm_python_cmd(self, ctx: commands.Context, *, obj: str = None):


### PR DESCRIPTION
Allows accessing `nextcord-ext-ipc` and `nextcord-ext-menus` docs with subcommands: `=rtfm ipc <obj>` and `=rtfm menus <obj>` respectively.

The commands have been tested:

![image](https://user-images.githubusercontent.com/20955511/142782247-060d2e08-afad-4537-8744-c1d4fe0881e3.png)

![image](https://user-images.githubusercontent.com/20955511/142782248-0505a1ac-7d64-4fac-830c-13cc33975e6c.png)
