### PR TITLE
Fix a couple of things.

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -42,10 +42,9 @@ async def close_help_thread(method: str, thread_channel, thread_author):
     =close command.
     """
     if not thread_channel.last_message or not thread_channel.last_message_id:
-        _last_msg = ((await thread_channel.history(oldest_first = True, limit = 1)).flatten())[0]
+        _last_msg = ((await thread_channel.history(limit = 1)).flatten())[0]
     else:
-        _msg_id = getattr(thread_channel.last_message, "id", None) or thread_channel.last_message_id
-        _last_msg = thread_channel.get_partial_message(_msg_id)
+        _last_msg = thread_channel.get_partial_message(thread_channel.last_message_id)
 
     thread_jump_url = _last_msg.jump_url
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -41,11 +41,12 @@ async def close_help_thread(method: str, thread_channel, thread_author):
     """Closes a help thread. Is called from either the close button or the
     =close command.
     """
-    if not getattr(thread_channel, "last_message", None) or not thread_channel.last_message_id:
+    if not thread_channel.last_message or not thread_channel.last_message_id:
         _last_msg = ((await thread_channel.history(oldest_first = True, limit = 1)).flatten())[0]
     else:
-        _last_msg = await thread_channel.fetch_message(thread_channel.last_message_id)
-        
+        _msg_id = getattr(thread_channel.last_message, "id", None) or thread_channel.last_message_id
+        _last_msg = thread_channel.get_partial_message(_msg_id)
+
     thread_jump_url = _last_msg.jump_url
 
     dm_embed_thumbnail = thread_channel.guild.icon.url


### PR DESCRIPTION
1. `Thread.last_message/_id` being `None` and breaking the closing process. This is resolved by checking and then getting it from `Thread.history` instead and also removed a not needed API call.
2. Added a `try-except` statement to a DM line because this can cause issues when the user's DMs are not open.
3. Fix the `Close` button not getting disabled when clicked.
4. Made the `on_thread_member_remove` event use the `close_help_thread` helper function.