### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,6 +37,8 @@ async def on_command_error(ctx, error):
 
 @bot.listen()
 async def on_message(message):
+    if not message.author.bot:
+        return
     if result := issue_regex.search(message.content):
         issue_id = result.groups()[0]
         await message.channel.send(f"https://github.com/nextcord/nextcord/issues/{issue_id}")


### PR DESCRIPTION
Issue regex match replies to all messages, even bot messages. (##issue_id)
Add check to avoid this and prevent abuse.

When an issue is mentioned, i.e. ##issue_id, the bot should not reply if the author is a bot.
Fix this by adding a check of author.bot not being... a bot?