### PR TITLE
Fix: Respond on command_not_found

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,6 @@ discord_regex = compile(r"#!(\d+)")
 @bot.event
 async def on_command_error(ctx, error):
     if isinstance(error, errors.CommandNotFound):
-        await ctx.channel.send("This command does not exist.")
         return
     elif isinstance(error, errors.TooManyArguments):
         await ctx.channel.send("You are giving too many arguments!")


### PR DESCRIPTION
Why do we require bots (for adding them to the discord) not to respond to command_not_found errors while Previous does this?