### PR TITLE
Improve help threads

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -116,7 +116,7 @@ class HelpButton(ui.Button["HelpView"]):
             return message.author.id == interaction.user.id and message.channel.id == thread.id and not thread.archived  # type: ignore
 
         try:
-            await self.bot.wait_for("message", timeout=5, check=yeet) # 900 = 15 minutes
+            await self.bot.wait_for("message", timeout=900, check=yeet) # 900 = 15 minutes
         except TimeoutError:
             if thread.archived:
                 return

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,10 +1,6 @@
 from typing import Dict, Optional
 from asyncio import TimeoutError
 
-from nextcord.utils import T
-
-from .utils.split_txtfile import split_txtfile
-
 from nextcord.ext import commands
 from nextcord import (
     Button,
@@ -22,6 +18,9 @@ from nextcord import (
     Message,
     ui,
 )
+
+from .utils.split_txtfile import split_txtfile
+
 
 HELP_CHANNEL_ID: int = 881965127031722004
 HELP_LOGS_CHANNEL_ID: int = 883035085434142781

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,4 +1,6 @@
-from typing import Dict, NamedTuple, Optional
+from typing import Dict, Optional
+from asyncio import TimeoutError
+
 from .utils.split_txtfile import split_txtfile
 
 from nextcord.ext import commands
@@ -9,14 +11,14 @@ from nextcord import (
     Colour,
     Embed,
     Forbidden,
-    Guild,
     HTTPException,
     Interaction,
     Member,
     MessageType,
     Thread,
     ThreadMember,
-    ui
+    Message,
+    ui,
 )
 
 HELP_CHANNEL_ID: int = 881965127031722004
@@ -43,7 +45,7 @@ async def close_help_thread(method: str, thread_channel, thread_author):
     =close command.
     """
     if not thread_channel.last_message or not thread_channel.last_message_id:
-        _last_msg = ((await thread_channel.history(limit = 1)).flatten())[0]
+        _last_msg = (await thread_channel.history(limit = 1).flatten())[0]
     else:
         _last_msg = thread_channel.get_partial_message(thread_channel.last_message_id)
 
@@ -62,8 +64,7 @@ async def close_help_thread(method: str, thread_channel, thread_author):
     # Make some slight changes to the previous thread-closer embed
     # to send to the user via DM.
     embed_reply.title = "Your help thread in the Nextcord server has been closed."
-    embed_reply.description += (f"\n\nYou can use [**this link**]({thread_jump_url}) to "
-                                "access the archived thread for future reference")
+    embed_reply.description = f"\n\nYou can use [**this link**]({thread_jump_url}) to access the archived thread for future reference"
     embed_reply.set_thumbnail(url=dm_embed_thumbnail)
     try:
         await thread_author.send(embed=embed_reply)
@@ -71,12 +72,14 @@ async def close_help_thread(method: str, thread_channel, thread_author):
         pass
 
 class HelpButton(ui.Button["HelpView"]):
-    def __init__(self, help_type: str, *, style: ButtonStyle, custom_id: str):
+    def __init__(self, bot: commands.Bot, help_type: str, *, style: ButtonStyle, custom_id: str):
         super().__init__(label = f"{help_type} help", style = style, custom_id = f"{CUSTOM_ID_PREFIX}{custom_id}")
-        self._help_type = help_type
+        self.bot: commands.Bot = bot
+        self._help_type: str = help_type
 
-    async def create_help_thread(self, interaction: Interaction) -> None:
+    async def create_help_thread(self, interaction: Interaction) -> Thread:
         channel_type = ChannelType.private_thread if interaction.guild.premium_tier >= 2 else ChannelType.public_thread
+
         thread = await interaction.channel.create_thread(
             name = f"{self._help_type} help ({interaction.user})",
             type = channel_type
@@ -89,23 +92,39 @@ class HelpButton(ui.Button["HelpView"]):
         close_button_view._thread_author = interaction.user
 
         type_to_colour: Dict[str, Colour] = {
-            "Nextcord": Colour.red(),
+            "Nextcord": Colour.blurple(),
             "Python": Colour.green()
         }
 
         em = Embed(
             title = f"{self._help_type} Help needed!",
-            description = f"Alright now that we are all here to help, what do you need help with?",
+            description = f"What do you need help with?",
             colour = type_to_colour.get(self._help_type, Colour.blurple())
         )
-        em.set_footer(text = "You and the helpers can close this thread with the button")
+        em.set_footer(text = "You and the help moderators can close this thread with the button")
 
         msg = await thread.send(
-            content = f"<@&{HELPER_ROLE_ID}> | {interaction.user.mention}",
+            content = interaction.user.mention,
             embed = em,
             view = ThreadCloseView()
         )
         await msg.pin(reason = "First message in help thread with the close button.")
+        return thread
+
+    async def __launch_wait_for_message(self, thread: Thread, interaction: Interaction) -> None:
+        def yeet(message: Message) -> bool:
+            return message.author.id == interaction.user.id and message.channel.id == thread.id and not thread.archived  # type: ignore
+
+        try:
+            await self.bot.wait_for("message", timeout=5, check=yeet) # 900 = 15 minutes
+        except TimeoutError:
+            if thread.archived:
+                return
+            await close_help_thread("TIMEOUT [launch_wait_for_message]", thread, interaction.user)
+            return
+        else:
+            await thread.send(f"<@&{HELPER_ROLE_ID}>", delete_after=5)
+            return
 
     async def callback(self, interaction: Interaction):
         confirm_view = ConfirmView()
@@ -115,7 +134,7 @@ class HelpButton(ui.Button["HelpView"]):
                 _item.disabled = True
 
         confirm_content = "Are you really sure you want to make a help thread?"
-        await interaction.response.send_message(content = confirm_content, ephemeral = True, view = confirm_view)
+        await interaction.send(content = confirm_content, ephemeral = True, view = confirm_view)
         await confirm_view.wait()
         if confirm_view.value is False or confirm_view.value is None:
             disable_all_buttons()
@@ -124,15 +143,22 @@ class HelpButton(ui.Button["HelpView"]):
         else:
             disable_all_buttons()
             await interaction.edit_original_message(content = "Created!", view = confirm_view)
-            await self.create_help_thread(interaction)
+            created_thread = await self.create_help_thread(interaction)
+            await self.__launch_wait_for_message(created_thread, interaction)
 
 
 class HelpView(ui.View):
-    def __init__(self):
+    def __init__(self, bot: commands.Bot):
         super().__init__(timeout = None)
-        self.add_item(HelpButton("Nextcord", style = ButtonStyle.red, custom_id = "nextcord"))
-        self.add_item(HelpButton("Python", style = ButtonStyle.green, custom_id = "python"))
+        self.add_item(HelpButton(bot, "Nextcord", style = ButtonStyle.blurple, custom_id = "nextcord"))
+        self.add_item(HelpButton(bot, "Python", style = ButtonStyle.green, custom_id = "python"))
 
+    async def interaction_check(self, interaction: Interaction) -> bool:
+        if interaction.user.timeout is not None:
+            await interaction.send("You are currently timed out. Please wait until you are removed from it.", ephemeral=True)
+            return False
+
+        return await super().interaction_check(interaction)
 
 class ConfirmButton(ui.Button["ConfirmView"]):
     def __init__(self, label: str, style: ButtonStyle, *, custom_id: str):
@@ -163,15 +189,15 @@ class ThreadCloseView(ui.View):
     async def thread_close_button(self, button: Button, interaction: Interaction):
         if interaction.channel.archived:
             button.disabled = True
-            await interaction.message.edit(view = self)
+            await interaction.response.edit_message(view = self)
             return
 
         if not self._thread_author:
             await self._get_thread_author(interaction.channel)  # type: ignore
         
-        await close_help_thread("BUTTON", interaction.channel, self._thread_author)
         button.disabled = True
-        await interaction.message.edit(view = self)
+        await interaction.response.edit_message(view = self)
+        await close_help_thread("BUTTON", interaction.channel, self._thread_author)
 
     async def interaction_check(self, interaction: Interaction) -> bool:
         if not self._thread_author:
@@ -181,7 +207,15 @@ class ThreadCloseView(ui.View):
         if not isinstance(interaction.channel, Thread) or interaction.channel.parent_id != HELP_CHANNEL_ID:
             return False
 
-        return interaction.user.id == self._thread_author.id or interaction.user.get_role(HELP_MOD_ID)
+        if interaction.user.timeout is not None:
+            await interaction.send("You are currently timed out. Please wait until you are removed from it.", ephemeral=True)
+            return False
+
+        if interaction.user.id == self._thread_author.id or interaction.user.get_role(HELP_MOD_ID):
+            return True
+        else:
+            await interaction.send("You are not allowed to close this thread.", ephemeral=True)
+            return False
 
 
 class HelpCog(commands.Cog):
@@ -192,7 +226,7 @@ class HelpCog(commands.Cog):
     async def create_views(self):
         if getattr(self.bot, "help_view_set", False) is False:
             self.bot.help_view_set = True
-            self.bot.add_view(HelpView())
+            self.bot.add_view(HelpView(self.bot))
             self.bot.add_view(ThreadCloseView())
 
     @commands.Cog.listener()
@@ -220,15 +254,18 @@ class HelpCog(commands.Cog):
     @commands.is_owner()
     async def help_menu(self, ctx):
         for section in split_txtfile("helpguide.txt"):
-            await ctx.send(embed=Embed(description=section))
-        await ctx.send("**:white_check_mark:  If you've read the guidelines "
-                       "above, click a button to create a help thread!**",
-                       view = HelpView())
+            await ctx.send(embed=Embed(description=section, color=Colour.yellow()))
+
+        await ctx.send(
+            content = "**:white_check_mark: If you've read the guidelines above, click a button to create a help thread!**",
+            view = HelpView(self.bot)
+        )
 
     @commands.command()
     async def close(self, ctx):
         if not isinstance(ctx.channel, Thread) or ctx.channel.parent_id != HELP_CHANNEL_ID:
             return
+            
         thread_author = await get_thread_author(ctx.channel)
         await close_help_thread("COMMAND", ctx.channel, thread_author)
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -109,7 +109,7 @@ class HelpButton(ui.Button["HelpView"]):
             description = f"What do you need help with?",
             colour = type_to_colour.get(self._help_type, Colour.blurple())
         )
-        em.set_footer(text = "You and the helper can close this thread with the button")
+        em.set_footer(text = "You and the helpers can close this thread with the button")
 
         msg = await thread.send(
             content = interaction.user.mention,

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -122,7 +122,7 @@ class HelpButton(ui.Button["HelpView"]):
             return message.author.id == interaction.user.id and message.channel.id == thread.id and not thread.archived  # type: ignore
 
         try:
-            await self.bot.wait_for("message", timeout=900, check=is_allowed) # 900 = 15 minutes
+            await self.bot.wait_for("message", timeout=1800, check=is_allowed) # 1800 seconds = 30 minutes
         except TimeoutError:
             await close_help_thread("TIMEOUT [launch_wait_for_message]", thread, interaction.user)
             return

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -133,7 +133,7 @@ class HelpButton(ui.Button["HelpView"]):
             for _item in confirm_view.children:
                 _item.disabled = True
 
-        confirm_content = "Are you really sure you want to make a help thread?"
+        confirm_content = f"Are you really sure you want to make a {self._help_type} Help thread?"
         await interaction.send(content = confirm_content, ephemeral = True, view = confirm_view)
         await confirm_view.wait()
         if confirm_view.value is False or confirm_view.value is None:
@@ -211,11 +211,11 @@ class ThreadCloseView(ui.View):
             await interaction.send("You are currently timed out. Please wait until you are removed from it.", ephemeral=True)
             return False
 
-        if interaction.user.id == self._thread_author.id or interaction.user.get_role(HELP_MOD_ID):
-            return True
-        else:
+        elif interaction.user.id != self._thread_author.id and not interaction.user.get_role(HELP_MOD_ID):
             await interaction.send("You are not allowed to close this thread.", ephemeral=True)
             return False
+
+        return True            
 
 
 class HelpCog(commands.Cog):

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -72,7 +72,7 @@ async def close_help_thread(method: str, thread_channel, thread_author):
     # Make some slight changes to the previous thread-closer embed
     # to send to the user via DM.
     embed_reply.title = "Your help thread in the Nextcord server has been closed."
-    embed_reply.description = f"\n\nYou can use [**this link**]({thread_jump_url}) to access the archived thread for future reference"
+    embed_reply.description += f"\n\nYou can use [**this link**]({thread_jump_url}) to access the archived thread for future reference"
     if thread_channel.guild.icon:
         embed_reply.set_thumbnail(url=thread_channel.guild.icon.url)
     try:

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -50,7 +50,7 @@ async def close_help_thread(method: str, thread_channel, thread_author):
     """
 
     # no need to do any of this if the thread is already closed.
-    if thread_channel.archived or thread_channel.locked:
+    if (thread_channel.locked or thread_channel.archived):
         return
 
     print(method)
@@ -263,7 +263,10 @@ class HelpCog(commands.Cog):
     async def close_empty_threads(self):
         await self.bot.wait_until_ready()
         active_threads = await self.bot.get_guild(GUILD_ID).active_threads()
-        active_help_threads = [thread for thread in active_threads if not thread.archived and thread.parent_id == HELP_CHANNEL_ID]
+        active_help_threads = [
+            thread for thread in active_threads
+            if thread.parent_id == HELP_CHANNEL_ID and (not thread.locked or not thread.archived)
+        ]
         for thread in active_help_threads:
             thread_created_at = utils.snowflake_time(thread.id)
 

--- a/main.py
+++ b/main.py
@@ -48,17 +48,17 @@ async def on_message(message):
 async def todo(ctx):
     await ctx.send("https://github.com/nextcord/nextcord/projects/1 and going through all the issues")
 
-
+"""
 for filename in os.listdir("./cogs"):
     if filename.endswith(".py"):
         bot.load_extension(f"cogs.{filename[:-3]}")
     elif os.path.isfile(filename):
         print(f"Unable to load {filename[:-3]}")
-
+"""
 
 async def startup():
     bot.session = aiohttp.ClientSession()
 
-
+bot.load_extension("cogs.help")
 bot.loop.create_task(startup())
-bot.run(env["TOKEN"])
+bot.run("ODkwNjczNzkwNTg4MTcwMjQx.YUzOmw.qD-t7EDQ0o4hD2d0V8X7A3vzPxk")

--- a/main.py
+++ b/main.py
@@ -48,17 +48,17 @@ async def on_message(message):
 async def todo(ctx):
     await ctx.send("https://github.com/nextcord/nextcord/projects/1 and going through all the issues")
 
-"""
+
 for filename in os.listdir("./cogs"):
     if filename.endswith(".py"):
         bot.load_extension(f"cogs.{filename[:-3]}")
     elif os.path.isfile(filename):
         print(f"Unable to load {filename[:-3]}")
-"""
+
 
 async def startup():
     bot.session = aiohttp.ClientSession()
 
-bot.load_extension("cogs.help")
+
 bot.loop.create_task(startup())
-bot.run("ODkwNjczNzkwNTg4MTcwMjQx.YUzOmw.qD-t7EDQ0o4hD2d0V8X7A3vzPxk")
+bot.run(env["TOKEN"])


### PR DESCRIPTION
This PR does the following:

- Disallow timed-out users to open/close threads.
- Change the nextcord button style to blurple instead of red (why was it red?)
- Indefinitely fixes the close button (finally)
- Fixes an error that could appear when closing threads (awaiting .history)
- And now to the main change...

Implemented a wait_for that waits 30 minutes for the thread author to send a message else close it before pinging all the helpers.

- An ext.tasks.Loop that checks every 24 hours for empty threads and mentions the helper roles if needed or closes it.