### PR TITLE
Removing the open thread log user ping

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -20,6 +20,7 @@ from nextcord import (
     Message,
     ui,
     utils,
+    AllowedMentions
 )
 
 from .utils.split_txtfile import split_txtfile
@@ -96,7 +97,8 @@ class HelpButton(ui.Button["HelpView"]):
         )
 
         await interaction.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
-            content = f"Help thread for {self._help_type} created by {interaction.user.mention}: {thread.mention}!"
+            content = f"Help thread for {self._help_type} created by {interaction.user.mention}: {thread.mention}!",
+            allowed_mentions = AllowedMentions(users=False)
         )
         close_button_view = ThreadCloseView()
         close_button_view._thread_author = interaction.user


### PR DESCRIPTION
pls whenever I open a thread I get pinged twice (in the thread + in the log channel), so lets make the log channel not actually ping - yay.