### PR TITLE
Add thread statistics

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -439,9 +439,8 @@ class HelpCog(commands.Cog):
     async def close(self, ctx):
         if not isinstance(ctx.channel, Thread) or ctx.channel.parent_id != HELP_CHANNEL_ID:
             return
-            
-        first_thread_message = (await ctx.channel.history(limit=1, oldest_first=True).flatten())[0]
-        thread_author = first_thread_message.mentions[0]
+
+        thread_author = await get_thread_author(ctx.channel)
         if not (ctx.author.id == thread_author.id or ctx.author.get_role(HELP_MOD_ID)):
             return await ctx.send("You are not allowed to close this thread.")
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -434,6 +434,9 @@ class HelpCog(commands.Cog):
         if not (isinstance(ctx.channel, Thread) and ctx.channel.parent.id == HELP_CHANNEL_ID):  # type: ignore
             return await ctx.send("This command can only be used in help threads!")
 
+        # generic_topic should be always set by help thread buttons
+        await stats_client.update_thread(thread_id=ctx.channel.id, specific_topic=topic)
+
         author = match(NAME_TOPIC_REGEX, ctx.channel.name).group(2)  # type: ignore
         await ctx.channel.edit(name=f"{topic} ({author})")
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -357,10 +357,15 @@ class HelpCog(commands.Cog):
         first_thread_message = (await ctx.channel.history(limit=1, oldest_first=True).flatten())[0]
         thread_author = first_thread_message.mentions[0]
         if not (ctx.author.id == thread_author.id or ctx.author.get_role(HELP_MOD_ID)):
-            return await ctx.send("You are not allowed to change the topic of this thread.")
+            return await ctx.send("You are not allowed to close this thread.")
 
         thread_author = await get_thread_author(ctx.channel)
         await close_help_thread("COMMAND", ctx.channel, thread_author)
+        await stats_client.update_thread(
+            thread_id=ctx.channel.id,
+            time_closed=datetime.datetime.utcnow(),
+            closed_by=ctx.author.id
+        )
 
     @commands.command()
     @commands.has_role(HELP_MOD_ID)

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -98,6 +98,7 @@ class HelpButton(ui.Button["HelpView"]):
             name = f"{self._help_type} help ({interaction.user})",
             type = ChannelType.public_thread,
         )
+        await stats_client.init_thread(thread_id=thread.id, help_type=self._help_type)
 
         await interaction.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
             content = f"Help thread for {self._help_type} created by {interaction.user.mention}: {thread.mention}!",
@@ -143,6 +144,7 @@ class HelpButton(ui.Button["HelpView"]):
             m: Message = await self.view.bot.wait_for("message", timeout=WAIT_FOR_TIMEOUT, check=is_allowed)
         except TimeoutError:
             await close_help_thread("TIMEOUT [launch_wait_for_message]", thread, interaction.user)
+            await stats_client.delete_init(thread_id=thread.id)
             return
         else:
             await thread.send(f"<@&{HELPER_ROLE_ID}>", delete_after=5)
@@ -334,6 +336,7 @@ class HelpCog(commands.Cog):
                     continue
             else:
                 await close_help_thread("TASK [close_empty_threads]", thread, thread_author)
+                await stats_client.delete_init(thread_id=thread.id)
                 continue
 
     @commands.command()

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -467,6 +467,16 @@ class HelpCog(commands.Cog):
 
     @commands.command()
     @commands.has_role(HELP_MOD_ID)
+    async def status(self, ctx):
+        if not (isinstance(ctx.channel, Thread) and ctx.channel.parent.id == HELP_CHANNEL_ID):  # type: ignore
+            return await ctx.send("This command can only be used in help threads!")
+
+        author = match(NAME_TOPIC_REGEX, ctx.channel.name).group(2)  # type: ignore
+        # TODO Regex to also get current topic so we only replace emoji
+        await ctx.channel.edit(name=f"{topic} ({author})")
+
+    @commands.command()
+    @commands.has_role(HELP_MOD_ID)
     async def transfer(self, ctx, *, new_author: Member):
         if not (isinstance(ctx.channel, Thread) and ctx.channel.parent_id == HELP_CHANNEL_ID):  # type: ignore
             return await ctx.send("This command can only be used in help threads!")

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -147,8 +147,7 @@ class HelpButton(ui.Button["HelpView"]):
         else:
             await thread.send(f"<@&{HELPER_ROLE_ID}>", delete_after=5)
 
-            role = thread.guild.get_role(HELPER_ROLE_ID)
-            is_helper = role in m.author.roles
+            is_helper = bool(m.author.get_role(HELPER_ROLE_ID))
             await stats_client.create_thread(
                 thread_id=thread.id,
                 opened_by=thread.owner_id,
@@ -275,8 +274,7 @@ class HelpCog(commands.Cog):
                 await message.delete(delay=10)
 
             else:
-                role = message.guild.get_role(HELPER_ROLE_ID)
-                is_helper = role in message.author.roles
+                is_helper = bool(message.author.get_role(HELPER_ROLE_ID))
                 await stats_client.create_message(
                     is_helper=is_helper,
                     message_id=message.id,

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -22,32 +22,42 @@ from nextcord import (
     Message,
     ui,
     utils,
-    AllowedMentions
+    AllowedMentions,
 )
 
 from .utils.split_txtfile import split_txtfile
 from .utils.stats import StatsClient
 
-HELP_CHANNEL_ID: int = 881965127031722004
-HELP_LOGS_CHANNEL_ID: int = 883035085434142781
-HELPER_ROLE_ID: int = 882192899519954944
-HELP_MOD_ID: int = 896860382226956329
-GUILD_ID: int = 881118111967883295
+# Commented ones are nc ones
+HELP_CHANNEL_ID: int = 954805334919237652
+# HELP_CHANNEL_ID: int = 881965127031722004
+HELP_LOGS_CHANNEL_ID: int = 890674366776475769
+# HELP_LOGS_CHANNEL_ID: int = 883035085434142781
+HELPER_ROLE_ID: int = 916051595794448396
+# HELPER_ROLE_ID: int = 882192899519954944
+HELP_MOD_ID: int = 916051618187870280
+# HELP_MOD_ID: int = 896860382226956329
+GUILD_ID: int = 890673374731321395
+# GUILD_ID: int = 881118111967883295
 CUSTOM_ID_PREFIX: str = "help:"
 NAME_TOPIC_REGEX: str = r"^(?P<topic>.*?) \((?P<author>[^)]*[^(]*)\)$"
-WAIT_FOR_TIMEOUT: int = 1800 # 30 minutes
+WAIT_FOR_TIMEOUT: int = 1800  # 30 minutes
 
-timeout_message: str = "You are currently timed out, please wait until it ends before trying again"
-closing_message = ("If your question has not been answered or your issue not "
-                   "resolved, we suggest taking a look at [Python Discord's Guide to "
-                   "Asking Good Questions](https://www.pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/) "
-                   "to get more effective help.")
+timeout_message: str = (
+    "You are currently timed out, please wait until it ends before trying again"
+)
+closing_message = (
+    "If your question has not been answered or your issue not "
+    "resolved, we suggest taking a look at [Python Discord's Guide to "
+    "Asking Good Questions](https://www.pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/) "
+    "to get more effective help."
+)
 
 stats_client: StatsClient = StatsClient(None)
 
 
 async def get_thread_author(channel: Thread) -> Member:
-    history = channel.history(oldest_first = True, limit = 1)
+    history = channel.history(oldest_first=True, limit=1)
     history_flat = await history.flatten()
     user = history_flat[0].mentions[0]
     return user
@@ -59,24 +69,28 @@ async def close_help_thread(method: str, thread_channel, thread_author):
     """
 
     # no need to do any of this if the thread is already closed.
-    if (thread_channel.locked or thread_channel.archived):
+    if thread_channel.locked or thread_channel.archived:
         return
 
     if not thread_channel.last_message or not thread_channel.last_message_id:
-        _last_msg = (await thread_channel.history(limit = 1).flatten())[0]
+        _last_msg = (await thread_channel.history(limit=1).flatten())[0]
     else:
         _last_msg = thread_channel.get_partial_message(thread_channel.last_message_id)
 
     thread_jump_url = _last_msg.jump_url
 
-    embed_reply = Embed(title="This thread has now been closed",
-                        description=closing_message,
-                        colour=Colour.dark_theme())
+    embed_reply = Embed(
+        title="This thread has now been closed",
+        description=closing_message,
+        colour=Colour.dark_theme(),
+    )
 
-    await thread_channel.send(embed=embed_reply)  # Send the closing message to the help thread
-    await thread_channel.edit(locked = True, archived = True)  # Lock thread
+    await thread_channel.send(
+        embed=embed_reply
+    )  # Send the closing message to the help thread
+    await thread_channel.edit(locked=True, archived=True)  # Lock thread
     await thread_channel.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(  # Send log
-        content = f"Help thread {thread_channel.name} (created by {thread_author.name}) has been closed."
+        content=f"Help thread {thread_channel.name} (created by {thread_author.name}) has been closed."
     )
     # Make some slight changes to the previous thread-closer embed
     # to send to the user via DM.
@@ -89,57 +103,56 @@ async def close_help_thread(method: str, thread_channel, thread_author):
     except (HTTPException, Forbidden):
         pass
 
+
 class TopicDropdown(nextcord.ui.Select):
     def __init__(self):
 
         # Set the options that will be presented inside the dropdown
         options = [
             nextcord.SelectOption(
-                label='Python help',
-                description='Questions related to Python, but not Nextcord.',
+                label="Python help",
+                description="Questions related to Python, but not Nextcord.",
             ),
             nextcord.SelectOption(
-                label='Nextcord',
-                description='Questions which are related to Nextcord and '
-                            'do not fit into other more specific categories.'
+                label="Nextcord",
+                description="Questions which are related to Nextcord and "
+                "do not fit into other more specific categories.",
             ),
             nextcord.SelectOption(
                 label="Text commands",
-                description="Questions related to nextcord.ext.commands"
+                description="Questions related to nextcord.ext.commands",
             ),
             nextcord.SelectOption(
                 label="Slash commands",
-                description="Questions related to slash commands, application commands, etc"
+                description="Questions related to slash commands, application commands, etc",
             ),
             nextcord.SelectOption(
                 label="Migrating",
-                description="Any questions relating to migrating from discord.py to Nextcord"
+                description="Any questions relating to migrating from discord.py to Nextcord",
             ),
             nextcord.SelectOption(
-                label="Hosting",
-                description="Any questions related to hosting your bot"
+                label="Hosting", description="Any questions related to hosting your bot"
             ),
             nextcord.SelectOption(
                 label="Databases",
-                description="Any questions related to using a database with Python"
+                description="Any questions related to using a database with Python",
             ),
             nextcord.SelectOption(
-                label='Misc',
-                description="Doesn't fit into any other categories listed."
+                label="Misc",
+                description="Doesn't fit into any other categories listed.",
             ),
         ]
 
-        # The placeholder is what will be shown when no option is chosen
-        # The min and max values indicate we can only pick one of the three options
-        # The options parameter defines the dropdown options. We defined this above
-        super().__init__(placeholder='Choose your favourite colour...', min_values=1, max_values=1, options=options)
+        super().__init__(
+            placeholder="Choose your favourite colour...",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
 
     async def callback(self, interaction: nextcord.Interaction):
-        # Use the interaction object to send a response message containing
-        # the user's favourite colour or choice. The self object refers to the
-        # Select object, and the values attribute gets a list of the user's
-        # selected options. We only want the first one.
-        await interaction.response.send_message(f'Your favourite colour is {self.values[0]}')
+        # TODO Set topic here
+        pass
 
 
 class TopicView(nextcord.ui.View):
@@ -151,13 +164,19 @@ class TopicView(nextcord.ui.View):
         self.add_item(self.dropdown)
 
 
-
 class HelpButton(ui.Button["HelpView"]):
-    def __init__(self, help_type: str, *, style: ButtonStyle, custom_id: str, row: Optional[int]=None):
+    def __init__(
+        self,
+        help_type: str,
+        *,
+        style: ButtonStyle,
+        custom_id: str,
+        row: Optional[int] = None,
+    ):
         super().__init__(
-            label = f"{help_type} help",
-            style = style,
-            custom_id = f"{CUSTOM_ID_PREFIX}{custom_id}",
+            label=f"{help_type} help",
+            style=style,
+            custom_id=f"{CUSTOM_ID_PREFIX}{custom_id}",
             row=row,
         )
         self._help_type: str = help_type
@@ -170,44 +189,50 @@ class HelpButton(ui.Button["HelpView"]):
         await stats_client.init_thread(thread_id=thread.id, help_type=self._help_type)
 
         await interaction.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
-            content = f"Help thread for {self._help_type} created by {interaction.user.mention}: {thread.mention}!",
-            allowed_mentions = AllowedMentions(users=False)
+            content=f"Help thread for {self._help_type} created by {interaction.user.mention}: {thread.mention}!",
+            allowed_mentions=AllowedMentions(users=False),
         )
 
         em = Embed(
-            title = f"{self._help_type} Help thread",
-            colour = Colour.blurple(),
-            description = (
+            title=f"{self._help_type} Help thread",
+            colour=Colour.blurple(),
+            description=(
                 "Please explain your issue in detail, helpers will respond as soon as possible."
                 "\n\n**Please include the following in your initial message:**"
                 "\n- Relevant code\n- Error (if present)\n- Expected behavior"
                 f"\n\nRefer for more to our help guildlines in <#{HELP_CHANNEL_ID}>"
-            )
+            ),
         )
-        em.set_footer(text = "You can close this thread with the button or =close command.")
+        em.set_footer(
+            text="You can close this thread with the button or =close command."
+        )
 
         close_button_view = ThreadCloseView()
 
         msg = await thread.send(
-            content = interaction.user.mention,
-            embed = em,
-            view = close_button_view
+            content=interaction.user.mention, embed=em, view=close_button_view
         )
         # it's a persistent view, we only need the button.
         close_button_view.stop()
-        await msg.pin(reason = "First message in help thread with the close button.")
+        await msg.pin(reason="First message in help thread with the close button.")
         return thread
 
-    async def __launch_wait_for_message(self, thread: Thread, interaction: Interaction) -> None:
+    async def __launch_wait_for_message(
+        self, thread: Thread, interaction: Interaction
+    ) -> None:
         assert self.view is not None
-        
+
         def is_allowed(message: Message) -> bool:
             return message.author.id == interaction.user.id and message.channel.id == thread.id and not thread.archived  # type: ignore
 
         try:
-            m: Message = await self.view.bot.wait_for("message", timeout=WAIT_FOR_TIMEOUT, check=is_allowed)
+            m: Message = await self.view.bot.wait_for(
+                "message", timeout=WAIT_FOR_TIMEOUT, check=is_allowed
+            )
         except TimeoutError:
-            await close_help_thread("TIMEOUT [launch_wait_for_message]", thread, interaction.user)
+            await close_help_thread(
+                "TIMEOUT [launch_wait_for_message]", thread, interaction.user
+            )
             await stats_client.delete_init(thread_id=thread.id)
             return
         else:
@@ -215,7 +240,7 @@ class HelpButton(ui.Button["HelpView"]):
             topic_view = TopicView()
             await thread.send(
                 f"Please pick the topic which best suits your needs, {interaction.user.mention}",
-                view=topic_view
+                view=topic_view,
             )
             await topic_view.wait()
             selected_item = topic_view.dropdown.values[0]
@@ -236,7 +261,7 @@ class HelpButton(ui.Button["HelpView"]):
                 initial_time_sent=m.created_at,
                 time_opened=thread.created_at,
                 initial_message_is_helper=is_helper,
-                generic_topic=selected_item
+                generic_topic=selected_item,
             )
             return
 
@@ -247,23 +272,33 @@ class HelpButton(ui.Button["HelpView"]):
             for _item in confirm_view.children:
                 _item.disabled = True
 
-        confirm_content = f"Are you really sure you want to make a {self._help_type} help thread?"
-        await interaction.send(content = confirm_content, ephemeral = True, view = confirm_view)
+        confirm_content = (
+            f"Are you really sure you want to make a {self._help_type} help thread?"
+        )
+        await interaction.send(
+            content=confirm_content, ephemeral=True, view=confirm_view
+        )
         await confirm_view.wait()
         if confirm_view.value is False or confirm_view.value is None:
             disable_all_buttons()
-            content = "Ok, cancelled." if confirm_view.value is False else f"~~{confirm_content}~~ I guess not..."
-            await interaction.edit_original_message(content = content, view = confirm_view)
+            content = (
+                "Ok, cancelled."
+                if confirm_view.value is False
+                else f"~~{confirm_content}~~ I guess not..."
+            )
+            await interaction.edit_original_message(content=content, view=confirm_view)
         else:
             disable_all_buttons()
-            await interaction.edit_original_message(content = "Created!", view = confirm_view)
+            await interaction.edit_original_message(
+                content="Created!", view=confirm_view
+            )
             created_thread = await self.create_help_thread(interaction)
             await self.__launch_wait_for_message(created_thread, interaction)
 
 
 class HelpView(ui.View):
     def __init__(self, bot: commands.Bot):
-        super().__init__(timeout = None)
+        super().__init__(timeout=None)
         self.bot: commands.Bot = bot
 
         # First row, or 'main' items
@@ -271,7 +306,7 @@ class HelpView(ui.View):
             HelpButton(
                 "Open help thread",
                 style=ButtonStyle.blurple,
-                custom_id="new_help_thread"
+                custom_id="new_help_thread",
             )
         )
 
@@ -282,49 +317,62 @@ class HelpView(ui.View):
 
         return await super().interaction_check(interaction)
 
+
 class ConfirmButton(ui.Button["ConfirmView"]):
     def __init__(self, label: str, style: ButtonStyle, *, custom_id: str):
-        super().__init__(label = label, style = style, custom_id = f"{CUSTOM_ID_PREFIX}{custom_id}")
+        super().__init__(
+            label=label, style=style, custom_id=f"{CUSTOM_ID_PREFIX}{custom_id}"
+        )
 
     async def callback(self, interaction: Interaction):
-        self.view.value = True if self.custom_id == f"{CUSTOM_ID_PREFIX}confirm_button" else False
+        self.view.value = (
+            True if self.custom_id == f"{CUSTOM_ID_PREFIX}confirm_button" else False
+        )
         self.view.stop()
 
 
 class ConfirmView(ui.View):
     def __init__(self):
-        super().__init__(timeout = 10.0)
+        super().__init__(timeout=10.0)
         self.value = None
-        self.add_item(ConfirmButton("Yes", ButtonStyle.green, custom_id = "confirm_button"))
-        self.add_item(ConfirmButton("No", ButtonStyle.red, custom_id = "decline_button"))
+        self.add_item(
+            ConfirmButton("Yes", ButtonStyle.green, custom_id="confirm_button")
+        )
+        self.add_item(ConfirmButton("No", ButtonStyle.red, custom_id="decline_button"))
 
 
 class ThreadCloseView(ui.View):
     def __init__(self):
-        super().__init__(timeout = None)
+        super().__init__(timeout=None)
 
-    @ui.button(label = "Close", style = ButtonStyle.red, custom_id = f"{CUSTOM_ID_PREFIX}thread_close")  # type: ignore
+    @ui.button(label="Close", style=ButtonStyle.red, custom_id=f"{CUSTOM_ID_PREFIX}thread_close")  # type: ignore
     async def thread_close_button(self, button: Button, interaction: Interaction):
         button.disabled = True
-        await interaction.response.edit_message(view = self)
+        await interaction.response.edit_message(view=self)
         thread_author = await get_thread_author(interaction.channel)  # type: ignore
         await close_help_thread("BUTTON", interaction.channel, thread_author)
         await stats_client.update_thread(
             thread_id=interaction.channel.id,
             time_closed=datetime.datetime.utcnow(),
-            closed_by=interaction.user.id
+            closed_by=interaction.user.id,
         )
 
     async def interaction_check(self, interaction: Interaction) -> bool:
 
         # because we aren't assigning the persistent view to a message_id.
-        if not isinstance(interaction.channel, Thread) or interaction.channel.parent_id != HELP_CHANNEL_ID:
+        if (
+            not isinstance(interaction.channel, Thread)
+            or interaction.channel.parent_id != HELP_CHANNEL_ID
+        ):
             return False
 
-        if (interaction.channel.archived or interaction.channel.locked):  # type: ignore
+        if interaction.channel.archived or interaction.channel.locked:  # type: ignore
             return False
 
-        if isinstance(interaction.user, Member) and interaction.user.timeout is not None:
+        if (
+            isinstance(interaction.user, Member)
+            and interaction.user.timeout is not None
+        ):
             await interaction.send(timeout_message, ephemeral=True)
             return False
 
@@ -332,18 +380,17 @@ class ThreadCloseView(ui.View):
         if interaction.user.id == thread_author.id or interaction.user.get_role(HELP_MOD_ID):  # type: ignore
             return True
         else:
-            await interaction.send("You are not allowed to close this thread.", ephemeral=True)
+            await interaction.send(
+                "You are not allowed to close this thread.", ephemeral=True
+            )
             return False
+
 
 class HelpCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.close_empty_threads.start()
         self.bot.loop.create_task(self.create_views())
-
-        # Funky, but saves rewriting everything.
-        global stats_client
-        stats_client.session = bot.session
 
     async def create_views(self):
         if getattr(self.bot, "help_view_set", False) is False:
@@ -353,10 +400,16 @@ class HelpCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message: Message):
-        if message.channel.id == HELP_CHANNEL_ID and message.type is MessageType.thread_created:
-            await message.delete(delay = 5)
+        if (
+            message.channel.id == HELP_CHANNEL_ID
+            and message.type is MessageType.thread_created
+        ):
+            await message.delete(delay=5)
 
-        if isinstance(message.channel, Thread) and message.channel.parent_id == HELP_CHANNEL_ID:
+        if (
+            isinstance(message.channel, Thread)
+            and message.channel.parent_id == HELP_CHANNEL_ID
+        ):
             if message.type is MessageType.pins_add:
                 await message.delete(delay=10)
 
@@ -384,7 +437,7 @@ class HelpCog(commands.Cog):
         await stats_client.update_thread(
             thread_id=thread.id,
             time_closed=datetime.datetime.utcnow(),
-            closed_by=member.id
+            closed_by=member.id,
         )
 
     @tasks.loop(hours=24)
@@ -393,8 +446,10 @@ class HelpCog(commands.Cog):
 
         guild = self.bot.get_guild(GUILD_ID)
         active_help_threads = [
-            thread for thread in await guild.active_threads()
-            if thread.parent_id == HELP_CHANNEL_ID and (not thread.locked and not thread.archived)
+            thread
+            for thread in await guild.active_threads()
+            if thread.parent_id == HELP_CHANNEL_ID
+            and (not thread.locked and not thread.archived)
         ]
 
         thread: Thread
@@ -402,11 +457,17 @@ class HelpCog(commands.Cog):
             thread_created_at = utils.snowflake_time(thread.id)
 
             # We don't want to close it before the wait_for.
-            if utils.utcnow() - timedelta(seconds=WAIT_FOR_TIMEOUT) <= thread_created_at:
+            if (
+                utils.utcnow() - timedelta(seconds=WAIT_FOR_TIMEOUT)
+                <= thread_created_at
+            ):
                 continue
-            
+
             all_messages = [
-                message for message in (await thread.history(limit=3, oldest_first=True).flatten())
+                message
+                for message in (
+                    await thread.history(limit=3, oldest_first=True).flatten()
+                )
                 if message.type is MessageType.default
             ]
             # can happen, ignore.
@@ -416,11 +477,16 @@ class HelpCog(commands.Cog):
             thread_author = all_messages[0].mentions[0]
             if len(all_messages) >= 2:
                 members = [x.id for x in await thread.fetch_members()]
-                if all_messages[1].author == thread_author and members == [thread_author.id, guild.me.id]:
+                if all_messages[1].author == thread_author and members == [
+                    thread_author.id,
+                    guild.me.id,
+                ]:
                     await thread.send(f"<@&{HELPER_ROLE_ID}>", delete_after=5)
                     continue
             else:
-                await close_help_thread("TASK [close_empty_threads]", thread, thread_author)
+                await close_help_thread(
+                    "TASK [close_empty_threads]", thread, thread_author
+                )
                 await stats_client.delete_init(thread_id=thread.id)
                 continue
 
@@ -431,19 +497,18 @@ class HelpCog(commands.Cog):
             await ctx.send(embed=Embed(description=section, color=Colour.yellow()))
 
         await ctx.send(
-            content = "**:white_check_mark: If you've read the guidelines above, click a button to create a help thread!**",
-            view = HelpView(self.bot)
+            content="**:white_check_mark: If you've read the guidelines above, click a button to create a help thread!**",
+            view=HelpView(self.bot),
         )
 
     @commands.command()
     async def close(self, ctx):
-        if not isinstance(ctx.channel, Thread) or ctx.channel.parent_id != HELP_CHANNEL_ID:
+        if (
+            not isinstance(ctx.channel, Thread)
+            or ctx.channel.parent_id != HELP_CHANNEL_ID
+        ):
             return
-<<<<<<< HEAD
 
-=======
-            
->>>>>>> ab6054e4d07ce6973f9518eba5ccbc964b2d941f
         thread_author = await get_thread_author(ctx.channel)
         if not (ctx.author.id == thread_author.id or ctx.author.get_role(HELP_MOD_ID)):
             return await ctx.send("You are not allowed to close this thread.")
@@ -452,7 +517,7 @@ class HelpCog(commands.Cog):
         await stats_client.update_thread(
             thread_id=ctx.channel.id,
             time_closed=datetime.datetime.utcnow(),
-            closed_by=ctx.author.id
+            closed_by=ctx.author.id,
         )
 
     @commands.command()
@@ -461,24 +526,10 @@ class HelpCog(commands.Cog):
         if not (isinstance(ctx.channel, Thread) and ctx.channel.parent.id == HELP_CHANNEL_ID):  # type: ignore
             return await ctx.send("This command can only be used in help threads!")
 
-<<<<<<< HEAD
         # generic_topic should be always set by help thread buttons
         await stats_client.update_thread(thread_id=ctx.channel.id, specific_topic=topic)
 
         author = match(NAME_TOPIC_REGEX, ctx.channel.name).group(2)  # type: ignore
-        await ctx.channel.edit(name=f"{topic} ({author})")
-
-    @commands.command()
-    @commands.has_role(HELP_MOD_ID)
-    async def status(self, ctx):
-        if not (isinstance(ctx.channel, Thread) and ctx.channel.parent.id == HELP_CHANNEL_ID):  # type: ignore
-            return await ctx.send("This command can only be used in help threads!")
-
-        author = match(NAME_TOPIC_REGEX, ctx.channel.name).group(2)  # type: ignore
-        # TODO Regex to also get current topic so we only replace emoji
-=======
-        author = match(NAME_TOPIC_REGEX, ctx.channel.name).group("author")  # type: ignore
->>>>>>> ab6054e4d07ce6973f9518eba5ccbc964b2d941f
         await ctx.channel.edit(name=f"{topic} ({author})")
 
     @commands.command()
@@ -488,15 +539,18 @@ class HelpCog(commands.Cog):
             return await ctx.send("This command can only be used in help threads!")
 
         topic = match(NAME_TOPIC_REGEX, ctx.channel.name).group("topic")  # type: ignore
-        first_thread_message = (await ctx.channel.history(limit=1, oldest_first=True).flatten())[0]
+        first_thread_message = (
+            await ctx.channel.history(limit=1, oldest_first=True).flatten()
+        )[0]
         old_author = first_thread_message.mentions[0]
 
         await ctx.channel.edit(name=f"{topic} ({new_author})")
         await first_thread_message.edit(content=new_author.mention)
         await ctx.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(  # Send log
-            content=f"Help thread {ctx.channel.mention} (created by {old_author.mention}) " \
-                    f"has been transferred to {new_author.mention} by {ctx.author.mention}.",
+            content=f"Help thread {ctx.channel.mention} (created by {old_author.mention}) "
+            f"has been transferred to {new_author.mention} by {ctx.author.mention}.",
         )
+
 
 def setup(bot):
     bot.add_cog(HelpCog(bot))

--- a/cogs/stars.py
+++ b/cogs/stars.py
@@ -10,7 +10,8 @@ class GitHubStars(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.__bot = bot
-        self.update_stars.start()
+        # TODO Uncomment
+        # self.update_stars.start()
 
     async def get_stars(self, repo: str) -> int:
         """Get number of GitHub stars for a given repo in the form 'owner/repository'"""

--- a/cogs/utils/stats.py
+++ b/cogs/utils/stats.py
@@ -30,6 +30,7 @@ class StatsClient:
     async def create_thread(
         self,
         thread_id: int,
+        *,
         opened_by: int,
         initial_author_id: int,
         initial_message_id: int,
@@ -135,6 +136,10 @@ class StatsClient:
         return self.base_url + route
 
     async def try_get(self, url: str, **kwargs) -> Optional[ClientResponse]:
+        if not self.session:
+            log.warning("Session was not set before attempted usage.")
+            return None
+
         try:
             async with self.session.get(
                 url,
@@ -144,10 +149,14 @@ class StatsClient:
                 return resp
 
         except HTTPException:
-            log.warning("Failed: GET %s", url)
+            log.debug("Failed: GET %s", url)
             return None
 
     async def try_post(self, url: str, data: Dict, **kwargs) -> Optional[ClientResponse]:
+        if not self.session:
+            log.warning("Session was not set before attempted usage.")
+            return None
+
         try:
             async with self.session.post(
                 url,
@@ -158,10 +167,14 @@ class StatsClient:
                 return resp
 
         except HTTPException:
-            log.warning("Failed: POST %s", url)
+            log.debug("Failed: POST %s", url)
             return None
 
     async def try_patch(self, url: str, data: Dict, **kwargs) -> Optional[ClientResponse]:
+        if not self.session:
+            log.warning("Session was not set before attempted usage.")
+            return None
+
         try:
             async with self.session.patch(
                 url,
@@ -172,5 +185,5 @@ class StatsClient:
                 return resp
 
         except HTTPException:
-            log.warning("Failed: PATCH %s", url)
+            log.debug("Failed: PATCH %s", url)
             return None

--- a/cogs/utils/stats.py
+++ b/cogs/utils/stats.py
@@ -30,6 +30,45 @@ class StatsClient:
             "content-type": "application/json"
         }
 
+    async def init_thread(
+        self,
+        thread_id: int,
+        help_type: str
+    ):
+        """Init a thread, without actually creating the thread."""
+        response: Optional[ClientResponse] = await self.try_post(
+            self.route("thread/partial"),
+            data={
+                "thread_id": thread_id,
+                "help_type": help_type,
+            }
+        )
+        if not response:
+            return None
+
+        elif response.status == 201:
+            return None
+
+        _json = await response.json()
+        log.info("Route failed: %s", _json["message"])
+
+    async def delete_init(
+        self,
+        thread_id: int,
+    ):
+        """Deletes the init thread entry."""
+        response: Optional[ClientResponse] = await self.try_delete(
+            self.route(f"thread/partial/{thread_id}")
+        )
+        if not response:
+            return None
+
+        elif response.status == 200:
+            return None
+
+        _json = await response.json()
+        log.info("Route failed: %s", _json["message"])
+
     async def create_thread(
         self,
         thread_id: int,
@@ -189,4 +228,21 @@ class StatsClient:
 
         except HTTPException:
             log.debug("Failed: PATCH %s", url)
+            return None
+
+    async def try_delete(self, url: str, **kwargs) -> Optional[ClientResponse]:
+        if not self.session:
+            log.warning("Session was not set before attempted usage.")
+            return None
+
+        try:
+            async with self.session.delete(
+                url,
+                headers=self.base_headers,
+                **kwargs
+            ) as resp:
+                return resp
+
+        except HTTPException:
+            log.debug("Failed: DELETE %s", url)
             return None

--- a/cogs/utils/stats.py
+++ b/cogs/utils/stats.py
@@ -17,10 +17,13 @@ class StatsClient:
 
         api_key: str = os.environ.get("STATS_API_KEY")
         if not api_key:
-            raise KeyError(
+            log.warning(
                 "STATS_API_KEY is a required environment variable."
                 "Please contact Skelmis#9135 for the current one."
             )
+
+            # This ensures it dies silently when used
+            self.session = None
 
         self.base_headers: Dict[str, str] = {
             "X-API-KEY": api_key,

--- a/cogs/utils/stats.py
+++ b/cogs/utils/stats.py
@@ -1,0 +1,176 @@
+import datetime
+import logging
+import os
+from typing import Dict, Optional
+
+from aiohttp import ClientSession, ClientResponse
+from aiohttp.web_exceptions import HTTPException
+
+log = logging.getLogger(__name__)
+
+
+class StatsClient:
+    """A simple interaction client for https://nextcord.koldfusion.xyz"""
+    def __init__(self, session: ClientSession):
+        self.session: ClientSession = session
+        self.base_url: str = "https://nextcord.koldfusion.xyz/api/v1/"
+
+        api_key: str = os.environ.get("STATS_API_KEY")
+        if not api_key:
+            raise KeyError(
+                "STATS_API_KEY is a required environment variable."
+                "Please contact Skelmis#9135 for the current one."
+            )
+
+        self.base_headers: Dict[str, str] = {
+            "X-API-KEY": api_key,
+            "content-type": "application/json"
+        }
+
+    async def create_thread(
+        self,
+        thread_id: int,
+        opened_by: int,
+        initial_author_id: int,
+        initial_message_id: int,
+        time_opened: datetime.datetime,  # Thread creation time
+        initial_time_sent: datetime.datetime,  # When the first message got sent
+        generic_topic: Optional[str] = "",
+        initial_message_is_helper: bool = False,
+    ) -> None:
+        """Called when the first actual message is sent in a thread."""
+        response: Optional[ClientResponse] = await self.try_post(
+            self.route("thread"),
+            data={
+                "thread_id": thread_id,
+                "time_opened": time_opened,
+                "opened_by": opened_by,
+                "generic_topic": generic_topic,
+                "initial_message": {
+                    "thread_id": thread_id,
+                    "message_id": initial_message_id,
+                    "author_id": initial_author_id,
+                    "time_sent": initial_time_sent,
+                    "is_helper": initial_message_is_helper
+                }
+            }
+        )
+        if not response:
+            return None
+
+        elif response.status == 201:
+            return None
+
+        _json = await response.json()
+        log.info("Route failed: %s", _json["message"])
+
+    async def create_message(
+        self,
+        *,
+        thread_id: int,
+        message_id: int,
+        author_id: int,
+        time_sent: datetime.datetime,
+        is_helper: bool = False
+    ) -> None:
+        """Called when a message is sent within a thread."""
+        response: Optional[ClientResponse] = await self.try_post(
+            self.route(f"thread/{thread_id}/messages"),
+            data={
+                "thread_id": thread_id,
+                "message_id": message_id,
+                "author_id": author_id,
+                "time_sent": time_sent,
+                "is_helper": is_helper
+            }
+        )
+        if not response:
+            return None
+
+        elif response.status == 201:
+            return None
+
+        _json = await response.json()
+        log.info("Route failed: %s", _json["message"])
+
+    async def update_thread(
+        self,
+        *,
+        thread_id: int,
+        closed_by: Optional[int] = None,
+        generic_topic: Optional[str] = None,
+        specific_topic: Optional[str] = None,
+        time_closed: Optional[datetime.datetime] = None
+    ) -> None:
+        """Called during things like the topic command."""
+        # We do this so as to *not* modify other params
+        data = {}
+        if closed_by:
+            data["closed_by"] = closed_by
+
+        if generic_topic:
+            data["generic_topic"] = generic_topic
+
+        if specific_topic:
+            data["specific_topic"] = specific_topic
+
+        if time_closed:
+            data["time_closed"] = time_closed
+
+        response: Optional[ClientResponse] = await self.try_patch(
+            self.route(f"thread/{thread_id}"),
+            data=data
+        )
+        if not response:
+            return None
+
+        elif response.status == 200:
+            return None
+
+        _json = await response.json()
+        log.info("Route failed: %s", _json["message"])
+
+    def route(self, route: str) -> str:
+        """Create a fully formed route from an API endpoint."""
+        return self.base_url + route
+
+    async def try_get(self, url: str, **kwargs) -> Optional[ClientResponse]:
+        try:
+            async with self.session.get(
+                url,
+                headers=self.base_headers,
+                **kwargs
+            ) as resp:
+                return resp
+
+        except HTTPException:
+            log.warning("Failed: GET %s", url)
+            return None
+
+    async def try_post(self, url: str, data: Dict, **kwargs) -> Optional[ClientResponse]:
+        try:
+            async with self.session.post(
+                url,
+                data=data,
+                headers=self.base_headers,
+                **kwargs
+            ) as resp:
+                return resp
+
+        except HTTPException:
+            log.warning("Failed: POST %s", url)
+            return None
+
+    async def try_patch(self, url: str, data: Dict, **kwargs) -> Optional[ClientResponse]:
+        try:
+            async with self.session.patch(
+                url,
+                data=data,
+                headers=self.base_headers,
+                **kwargs
+            ) as resp:
+                return resp
+
+        except HTTPException:
+            log.warning("Failed: PATCH %s", url)
+            return None

--- a/cogs/utils/stats.py
+++ b/cogs/utils/stats.py
@@ -179,7 +179,7 @@ class StatsClient:
 
     async def try_get(self, url: str, **kwargs) -> Optional[ClientResponse]:
         if not self.session:
-            log.warning("Session was not set before attempted usage.")
+            log.debug("Session was not set before attempted usage.")
             return None
 
         try:
@@ -196,7 +196,7 @@ class StatsClient:
 
     async def try_post(self, url: str, data: Dict, **kwargs) -> Optional[ClientResponse]:
         if not self.session:
-            log.warning("Session was not set before attempted usage.")
+            log.debug("Session was not set before attempted usage.")
             return None
 
         try:
@@ -214,7 +214,7 @@ class StatsClient:
 
     async def try_patch(self, url: str, data: Dict, **kwargs) -> Optional[ClientResponse]:
         if not self.session:
-            log.warning("Session was not set before attempted usage.")
+            log.debug("Session was not set before attempted usage.")
             return None
 
         try:
@@ -232,7 +232,7 @@ class StatsClient:
 
     async def try_delete(self, url: str, **kwargs) -> Optional[ClientResponse]:
         if not self.session:
-            log.warning("Session was not set before attempted usage.")
+            log.debug("Session was not set before attempted usage.")
             return None
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Tag-Epic <tagepicuwu@gmail.com>"]
 python = "^3.8"
 nextcord = "git+https://github.com/nextcord/nextcord.git#master"
 jishaku = "^2.2.0"
+algoliasearch = "^2.6.1"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
This PR is a work in progress, however, the code here can be reviewed against.

This PR will bring various thread-related statistics to Nextcord, with Previous acting as a data provider to my statistics service.

Done:
- Catch the initial topic on thread creation via button click
- Catch new thread messages
- Catch thread creation and deletion
- Add further buttons to the help menu to add further topics

TODO:

- Rework the topic command
    - Use a drop-down to provide generic categories (Statistic specific)
    - Use the user-provided input as channel name and specific_topic for statistics

Note ``algoliasearch`` is added as dep as a side effect due to it being required to run master branch.
