### PR TITLE
feat: Format help logs with emojis and embeds

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -83,15 +83,18 @@ async def close_help_thread(
     )  # Send the closing message to the help thread
     await thread_channel.edit(locked=True, archived=True)  # Lock thread
     # Send log
-    await thread_channel.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
-        embed=Embed(
-            title=":x: Closed help thread",
-            description=(
-                f"{thread_channel.mention}\n\nHelp thread created by {thread_author.mention} has been closed by {closed_by.mention} "
-                f"using **{method}**."
-            ),
-        )
+    embed_log = Embed(
+        title=":x: Closed help thread",
+        url=thread_channel.jump_url,
+        description=(
+            f"{thread_channel.mention}\n\nHelp thread created by {thread_author.mention} has been closed by {closed_by.mention} "
+            f"using **{method}**.\n\n"
+            f"Thread author: `{thread_author} ({thread_author.id})`\n"
+            f"Closed by: `{closed_by} ({closed_by.id})`"
+        ),
+        colour=0xDD2E44,  # Red
     )
+    await thread_channel.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(embed=embed_log)
     # Make some slight changes to the previous thread-closer embed
     # to send to the user via DM.
     embed_reply.title = "Your help thread in the Nextcord server has been closed."
@@ -120,12 +123,17 @@ class HelpButton(ui.Button["HelpView"]):
         )
 
         # Send log
-        await interaction.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
-            embed=Embed(
-                title=":white_check_mark: Help thread created",
-                description=f"{thread.mention}\n\nHelp thread for **{self._help_type}** created by {interaction.user.mention}!",
-            )
+        embed_log = Embed(
+            title=":white_check_mark: Help thread created",
+            url=thread.jump_url,
+            description=(
+                f"{thread.mention}\n\n"
+                f"Help thread for **{self._help_type}** created by {interaction.user.mention}!\n\n"
+                f"Created by: `{interaction.user} ({interaction.user.id})`"
+            ),
+            colour=0x77B255,  # Green
         )
+        await interaction.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(embed=embed_log)
 
         type_to_colour: Dict[str, Colour] = {
             "Nextcord": Colour.blurple(),
@@ -418,15 +426,19 @@ class HelpCog(commands.Cog):
         await ctx.channel.edit(name=f"{topic} ({new_author})")
         await first_thread_message.edit(content=new_author.mention)
         # Send log
-        await ctx.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
-            embed=Embed(
-                title=":arrow_right: Help thread transferred",
-                description=(
-                    f"{ctx.channel.mention}\n\nHelp thread created by {old_author.mention} "
-                    f"has been transferred to {new_author.mention} by {ctx.author.mention}."
-                ),
-            )
+        embed_log = Embed(
+            title=":arrow_right: Help thread transferred",
+            url=ctx.channel.jump_url,
+            description=(
+                f"{ctx.channel.mention}\n\nHelp thread created by {old_author.mention} "
+                f"has been transferred to {new_author.mention} by {ctx.author.mention}.\n\n"
+                f"Thread author: `{old_author} ({old_author.id})`\n"
+                f"New author: `{new_author} ({new_author.id})`\n"
+                f"Transferred by: `{ctx.author} ({ctx.author.id})`"
+            ),
+            colour=0x3B88C3,  # Blue
         )
+        await ctx.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(embed=embed_log)
 
 
 def setup(bot):

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,4 +1,5 @@
-from typing import Dict, Optional
+import time
+from typing import Dict
 from asyncio import TimeoutError
 from datetime import timedelta
 from re import match
@@ -70,7 +71,8 @@ async def close_help_thread(method: str, thread_channel, thread_author):
     await thread_channel.send(embed=embed_reply)  # Send the closing message to the help thread
     await thread_channel.edit(locked = True, archived = True)  # Lock thread
     await thread_channel.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(  # Send log
-        content = f"Help thread {thread_channel.name} (created by {thread_author.name}) has been closed."
+        content = f"<t:{int(time.time())}:R> :x: `{thread_channel.name}` Help thread (created by {thread_author.mention}) has been closed."
+        allowed_mentions = AllowedMentions(users=False)
     )
     # Make some slight changes to the previous thread-closer embed
     # to send to the user via DM.
@@ -95,7 +97,7 @@ class HelpButton(ui.Button["HelpView"]):
         )
 
         await interaction.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
-            content = f"Help thread for {self._help_type} created by {interaction.user.mention}: {thread.mention}!",
+            content = f"<t:{int(time.time())}:R> :white_check_mark: {thread.mention} Help thread for **{self._help_type}** created by {interaction.user.mention}!",
             allowed_mentions = AllowedMentions(users=False)
         )
 
@@ -340,8 +342,9 @@ class HelpCog(commands.Cog):
         await ctx.channel.edit(name=f"{topic} ({new_author})")
         await first_thread_message.edit(content=new_author.mention)
         await ctx.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(  # Send log
-            content=f"Help thread {ctx.channel.mention} (created by {old_author.mention}) " \
+            content=f"<t:{int(time.time())}:R> :arrow_right: {ctx.channel.mention} Help thread created by {old_author.mention} " \
                     f"has been transferred to {new_author.mention} by {ctx.author.mention}.",
+            allowed_mentions = AllowedMentions(users=False)
         )
 
 def setup(bot):

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -70,9 +70,12 @@ async def close_help_thread(method: str, thread_channel, thread_author):
 
     await thread_channel.send(embed=embed_reply)  # Send the closing message to the help thread
     await thread_channel.edit(locked = True, archived = True)  # Lock thread
-    await thread_channel.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(  # Send log
-        content = f"<t:{int(time.time())}:R> :x: `{thread_channel.name}` Help thread (created by {thread_author.mention}) has been closed."
-        allowed_mentions = AllowedMentions(users=False)
+    # Send log
+    await thread_channel.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
+        embed=Embed(
+            title=":x: Closed help thread",
+            description=f"{thread_channel.mention}\n\nHelp thread created by {thread_author.mention} has been closed by **{method}**",
+        )
     )
     # Make some slight changes to the previous thread-closer embed
     # to send to the user via DM.
@@ -96,9 +99,12 @@ class HelpButton(ui.Button["HelpView"]):
             type = ChannelType.public_thread,
         )
 
+        # Send log
         await interaction.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
-            content = f"<t:{int(time.time())}:R> :white_check_mark: {thread.mention} Help thread for **{self._help_type}** created by {interaction.user.mention}!",
-            allowed_mentions = AllowedMentions(users=False)
+            embed=Embed(
+                title=":white_check_mark: Help thread created",
+                description=f"{thread.mention}\n\nHelp thread for **{self._help_type}** created by {interaction.user.mention}!",
+            )
         )
 
         type_to_colour: Dict[str, Colour] = {
@@ -341,10 +347,15 @@ class HelpCog(commands.Cog):
 
         await ctx.channel.edit(name=f"{topic} ({new_author})")
         await first_thread_message.edit(content=new_author.mention)
-        await ctx.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(  # Send log
-            content=f"<t:{int(time.time())}:R> :arrow_right: {ctx.channel.mention} Help thread created by {old_author.mention} " \
-                    f"has been transferred to {new_author.mention} by {ctx.author.mention}.",
-            allowed_mentions = AllowedMentions(users=False)
+        # Send log
+        await ctx.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(
+            embed=Embed(
+                title=":arrow_right: Help thread transferred",
+                description=(
+                    f"{ctx.channel.mention}\n\nHelp thread created by {old_author.mention} "
+                    f"has been transferred to {new_author.mention} by {ctx.author.mention}."
+                ),
+            )
         )
 
 def setup(bot):

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,4 +1,3 @@
-import time
 from typing import Dict
 from asyncio import TimeoutError
 from datetime import timedelta

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 from asyncio import TimeoutError
 from datetime import timedelta
 from re import match

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -5,10 +5,10 @@ from re import match
 from typing import Dict, Union
 
 from nextcord import (
-    AllowedMentions,
     Button,
     ButtonStyle,
     ChannelType,
+    ClientUser,
     Colour,
     Embed,
     Forbidden,

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -70,6 +70,7 @@ async def close_help_thread(
         _last_msg = thread_channel.get_partial_message(thread_channel.last_message_id)
 
     thread_jump_url = _last_msg.jump_url
+    topic = match(NAME_TOPIC_REGEX, thread_channel.name).group("topic")  # type: ignore
 
     embed_reply = Embed(
         title="This thread has now been closed",
@@ -94,7 +95,7 @@ async def close_help_thread(
     # Make some slight changes to the previous thread-closer embed
     # to send to the user via DM.
     embed_reply.title = "Your help thread in the Nextcord server has been closed."
-    embed_reply.description += f"\n\nYou can use [**this link**]({thread_jump_url}) to access the archived thread for future reference"
+    embed_reply.description += f"\n\nTopic: **{topic}**\n\nYou can use [**this link**]({thread_jump_url}) to access the archived thread for future reference."
     if thread_channel.guild.icon:
         embed_reply.set_thumbnail(url=thread_channel.guild.icon.url)
     try:


### PR DESCRIPTION
This PR stylizes the `#help_logs` channel with emojis and embeds.

This makes the logs easier to read and distinguish different types of log messages from each other.

This PR also includes the close method and thread mention in the close thread logs.

Old logs:

![image](https://user-images.githubusercontent.com/20955511/158303027-43d12ceb-d92f-4c5c-b6e9-7354765f12d1.png)

New logs:

![image](https://user-images.githubusercontent.com/20955511/161412167-ff0689cf-0210-4703-81b6-e12d16f3fe48.png)

![image](https://user-images.githubusercontent.com/20955511/161412355-8d56cfae-0179-457a-8d4d-2c64b0b98004.png)


This has been tested locally.