### PR TITLE
Add support for reopening a help thread

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -325,7 +325,7 @@ class HelpCog(commands.Cog):
             await reopen_help_thread(
                 self.bot.user.id,
                 after,
-                "EVENT [ON_THREAD_UPDATE]",
+                "EVENT [on_thread_update]",
                 author=self.bot.user,
             )
    


### PR DESCRIPTION
This adds a `=reopen` command and supports un-archiving it manually. Check the function docstrings for information.


This was tested locally. Reviews are welcome.