### PR TITLE
fix: updated the Nextcord Documentaion link

### DIFF
--- a/cogs/docs.py
+++ b/cogs/docs.py
@@ -487,7 +487,7 @@ class Docs(commands.Cog):
 
     async def do_docs(self, ctx, key, obj):
         page_types = {
-            "master": "https://docs.nextcord.dev/en/latest",
+            "master": "https://docs.nextcord.dev/en/stable",
             "menus": "https://nextcord-ext-menus.readthedocs.io/en/latest",
             "ipc": "https://nextcord-ext-ipc.readthedocs.io/en/latest",
             "python": "https://docs.python.org/3",

--- a/cogs/docs.py
+++ b/cogs/docs.py
@@ -487,7 +487,7 @@ class Docs(commands.Cog):
 
     async def do_docs(self, ctx, key, obj):
         page_types = {
-            "master": "https://nextcord.readthedocs.io/en/latest",
+            "master": "https://docs.nextcord.dev/en/latest",
             "menus": "https://nextcord-ext-menus.readthedocs.io/en/latest",
             "ipc": "https://nextcord-ext-ipc.readthedocs.io/en/latest",
             "python": "https://docs.python.org/3",


### PR DESCRIPTION
Just changed the docs from `latest` to `stable` and used https://docs.nextcord.dev instead as per @ooliver1 's [request](https://ptb.discord.com/channels/881118111967883295/881118112492191796/964083154921082930).