### PR TITLE
Allowing Server Moderators to moderate help threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ You need a [consul](https://consul.io) instance running.
 ## Env vars
 ```sh
 GUILD_ID=... # The guild id the bot uses. This is the nextcord server.
-BOOSTER_ROLE_ID=... # The booster role. Currently used for booster bots
+BOOSTER_ROLE_ID=... # The booster role. Currently used for booster bots.
+SERVER_MOD_ROLE_ID=... # The server moderator role.
 
-HELP_LOG_CHANNEL_ID=... # The log channel the help cog uses
+HELP_LOG_CHANNEL_ID=... # The log channel the help cog uses.
 HELP_NOTIFICATION_ROLE_ID=... # The role that gets pinged in every help thread.
-HELP_MOD_ROLE_ID=... # The role that is allowed to moderate help channels
+HELP_MOD_ROLE_ID=... # The role that allows users to moderate help channels.
 
-BOT_LINKING_LOG_CHANNEL_ID=... # Logs for actions by the bot linking cog
+BOT_LINKING_LOG_CHANNEL_ID=... # Logs for actions by the bot linking cog.
 ```

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -413,7 +413,7 @@ class HelpCog(commands.Cog):
         await ctx.channel.edit(name=f"{topic} ({author})")
 
     @commands.command()
-    @commands.has_role(HELP_MOD_ID)
+    @commands.has_any_role(HELP_MOD_ID, SERVER_MOD_ID)
     async def transfer(self, ctx, *, new_author: Member):
         if not (isinstance(ctx.channel, Thread) and ctx.channel.parent_id == HELP_CHANNEL_ID):  # type: ignore
             return await ctx.send("This command can only be used in help threads!")

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -31,6 +31,7 @@ HELP_LOGS_CHANNEL_ID: int = int(env["HELP_LOG_CHANNEL_ID"])
 HELPER_ROLE_ID: int = int(env["HELP_NOTIFICATION_ROLE_ID"])
 HELP_MOD_ID: int = int(env["HELP_MOD_ROLE_ID"])
 GUILD_ID: int = int(env["GUILD_ID"])
+SERVER_MOD_ID: int = int(env["SERVER_MOD_ROLE_ID"])
 CUSTOM_ID_PREFIX: str = "help:"
 NAME_TOPIC_REGEX: str = r"^(?P<topic>.*?) \((?P<author>[^)]*[^(]*)\)$"
 WAIT_FOR_TIMEOUT: int = 1800  # 30 minutes
@@ -403,7 +404,7 @@ class HelpCog(commands.Cog):
         await close_help_thread("COMMAND", ctx.channel, thread_author, ctx.author)
 
     @commands.command()
-    @commands.has_role(HELP_MOD_ID)
+    @commands.has_any_role(HELP_MOD_ID, SERVER_MOD_ID)
     async def topic(self, ctx, *, topic: str):
         if not (isinstance(ctx.channel, Thread) and ctx.channel.parent.id == HELP_CHANNEL_ID):  # type: ignore
             return await ctx.send("This command can only be used in help threads!")


### PR DESCRIPTION
This can help server moderators as we know that some of them can not manage help threads if they do not have the Help Mod role as of yet. 

It is also a [suggestion](https://ptb.discord.com/channels/881118111967883295/903644157229281382/970553648625090591) that Koala9712 made in the Nextcord server. 
- I have also just added periods(`.`) to the README.md page because yes. 
- Added SERVER_MOD_ROLE_ID as a .env, for the Nextcord server's case, you would obviously get the Server Mod role ID.