### PR TITLE
[help] Improve topic command

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,8 +1,9 @@
+from typing import Dict, Union
+
 from asyncio import TimeoutError
 from datetime import timedelta
 from os import environ as env
 from re import match
-from typing import Dict, Union
 
 from nextcord import (
     Button,
@@ -21,8 +22,12 @@ from nextcord import (
     ThreadMember,
     ui,
     utils,
+    slash_command,
+    SlashOption
 )
+
 from nextcord.ext import commands, tasks
+from nextcord.ext.application_checks import has_role as application_checks_has_role
 
 from .utils.split_txtfile import split_txtfile
 
@@ -34,13 +39,13 @@ GUILD_ID: int = int(env["GUILD_ID"])
 CUSTOM_ID_PREFIX: str = "help:"
 NAME_TOPIC_REGEX: str = r"^(?P<topic>.*?) \((?P<author>[^)]*[^(]*)\)$"
 WAIT_FOR_TIMEOUT: int = 1800  # 30 minutes
-HELP_TOPIC_EMOJIS = {
-    "🐛": ("but report", "When there is a bug reported for Nextcord."),
-     "🔥": ("active", "When the thread is activily being used."),
-    "⏳":("stalled", "When response from the author is being awaited."),
-    "🤚": ("help needed", "When the author needs help."),
-     "📌":("pinned", "When the thread should stay open for a while."),
-    "⚠️": ("tos", "When something against the Terms of Service is being discussed."),	
+HELP_TOPIC_EMOJIS: Dict[str, str] = {
+    "🤚": "Help Needed",
+    "🔥": "Active",
+    "⏳": "Stalled",
+    "🐛": "Bug Report",
+    "📌": "Pinned",
+    "⚠️": "ToS",
 }
 
 closing_message = (
@@ -86,9 +91,7 @@ async def close_help_thread(
         colour=Colour.dark_theme(),
     )
 
-    await thread_channel.send(
-        embed=embed_reply
-    )  # Send the closing message to the help thread
+    await thread_channel.send(embed=embed_reply)  # Send the closing message to the help thread
     await thread_channel.edit(locked=True, archived=True)  # Lock thread
     # Send log
     embed_log = Embed(
@@ -158,32 +161,24 @@ class HelpButton(ui.Button["HelpView"]):
                 f"\n\nRefer for more to our help guildlines in <#{HELP_CHANNEL_ID}>"
             ),
         )
-        em.set_footer(
-            text="You can close this thread with the button or =close command."
-        )
+        em.set_footer(text="You can close this thread with the button or =close command.")
 
         close_button_view = ThreadCloseView()
 
-        msg = await thread.send(
-            content=interaction.user.mention, embed=em, view=close_button_view
-        )
+        msg = await thread.send(content=interaction.user.mention, embed=em, view=close_button_view)
         # it's a persistent view, we only need the button.
         close_button_view.stop()
         await msg.pin(reason="First message in help thread with the close button.")
         return thread
 
-    async def __launch_wait_for_message(
-        self, thread: Thread, interaction: Interaction
-    ) -> None:
+    async def __launch_wait_for_message(self, thread: Thread, interaction: Interaction) -> None:
         assert self.view is not None
 
         def is_allowed(message: Message) -> bool:
             return message.author.id == interaction.user.id and message.channel.id == thread.id and not thread.archived  # type: ignore
 
         try:
-            await self.view.bot.wait_for(
-                "message", timeout=WAIT_FOR_TIMEOUT, check=is_allowed
-            )
+            await self.view.bot.wait_for("message", timeout=WAIT_FOR_TIMEOUT, check=is_allowed)
         except TimeoutError:
             await close_help_thread(
                 "TIMEOUT [launch_wait_for_message]",
@@ -203,26 +198,16 @@ class HelpButton(ui.Button["HelpView"]):
             for _item in confirm_view.children:
                 _item.disabled = True
 
-        confirm_content = (
-            f"Are you really sure you want to make a {self._help_type} help thread?"
-        )
-        await interaction.send(
-            content=confirm_content, ephemeral=True, view=confirm_view
-        )
+        confirm_content = f"Are you really sure you want to make a {self._help_type} help thread?"
+        await interaction.send(content=confirm_content, ephemeral=True, view=confirm_view)
         await confirm_view.wait()
         if confirm_view.value is False or confirm_view.value is None:
             disable_all_buttons()
-            content = (
-                "Ok, cancelled."
-                if confirm_view.value is False
-                else f"~~{confirm_content}~~ I guess not..."
-            )
+            content = "Ok, cancelled." if confirm_view.value is False else f"~~{confirm_content}~~ I guess not..."
             await interaction.edit_original_message(content=content, view=confirm_view)
         else:
             disable_all_buttons()
-            await interaction.edit_original_message(
-                content="Created!", view=confirm_view
-            )
+            await interaction.edit_original_message(content="Created!", view=confirm_view)
             created_thread = await self.create_help_thread(interaction)
             await self.__launch_wait_for_message(created_thread, interaction)
 
@@ -232,22 +217,16 @@ class HelpView(ui.View):
         super().__init__(timeout=None)
         self.bot: commands.Bot = bot
 
-        self.add_item(
-            HelpButton("Nextcord", style=ButtonStyle.blurple, custom_id="nextcord")
-        )
+        self.add_item(HelpButton("Nextcord", style=ButtonStyle.blurple, custom_id="nextcord"))
         self.add_item(HelpButton("Python", style=ButtonStyle.green, custom_id="python"))
 
 
 class ConfirmButton(ui.Button["ConfirmView"]):
     def __init__(self, label: str, style: ButtonStyle, *, custom_id: str):
-        super().__init__(
-            label=label, style=style, custom_id=f"{CUSTOM_ID_PREFIX}{custom_id}"
-        )
+        super().__init__(label=label, style=style, custom_id=f"{CUSTOM_ID_PREFIX}{custom_id}")
 
     async def callback(self, interaction: Interaction):
-        self.view.value = (
-            True if self.custom_id == f"{CUSTOM_ID_PREFIX}confirm_button" else False
-        )
+        self.view.value = True if self.custom_id == f"{CUSTOM_ID_PREFIX}confirm_button" else False
         self.view.stop()
 
 
@@ -255,9 +234,7 @@ class ConfirmView(ui.View):
     def __init__(self):
         super().__init__(timeout=10.0)
         self.value = None
-        self.add_item(
-            ConfirmButton("Yes", ButtonStyle.green, custom_id="confirm_button")
-        )
+        self.add_item(ConfirmButton("Yes", ButtonStyle.green, custom_id="confirm_button"))
         self.add_item(ConfirmButton("No", ButtonStyle.red, custom_id="decline_button"))
 
 
@@ -270,17 +247,12 @@ class ThreadCloseView(ui.View):
         button.disabled = True
         await interaction.response.edit_message(view=self)
         thread_author = await get_thread_author(interaction.channel)  # type: ignore
-        await close_help_thread(
-            "BUTTON", interaction.channel, thread_author, interaction.user
-        )
+        await close_help_thread("BUTTON", interaction.channel, thread_author, interaction.user)
 
     async def interaction_check(self, interaction: Interaction) -> bool:
 
         # because we aren't assigning the persistent view to a message_id.
-        if (
-            not isinstance(interaction.channel, Thread)
-            or interaction.channel.parent_id != HELP_CHANNEL_ID
-        ):
+        if not isinstance(interaction.channel, Thread) or interaction.channel.parent_id != HELP_CHANNEL_ID:
             return False
 
         if interaction.channel.archived or interaction.channel.locked:  # type: ignore
@@ -290,42 +262,9 @@ class ThreadCloseView(ui.View):
         if interaction.user.id == thread_author.id or interaction.user.get_role(HELP_MOD_ID):  # type: ignore
             return True
         else:
-            await interaction.send(
-                "You are not allowed to close this thread.", ephemeral=True
-            )
+            await interaction.send("You are not allowed to close this thread.", ephemeral=True)
             return False
 
-class TopicEmojiSelectorView(ui.View):
-    def __init__(self, command_author_id: int):
-        self.command_author_id = command_author_id
-        super().__init__(timeout=WAIT_FOR_TIMEOUT)
-        self.value = None
-        self.add_item(TopicEmojiSelector())
-
-    async def on_timeout(self) -> None:
-        await self.message.delete()  # type: ignore
-      
-    async def interaction_check(self, interaction: Interaction) -> bool:
-        return interaction.user.id == self.command_author_id  # type: ignore
-class TopicEmojiSelector(ui.Select):
-    def __init__(self):
-        super().__init__(
-            custom_id="topic_emoji_selector",
-            placeholder="Select a topic emoji",
-            min_values=1
-        )
-        for emoji, (label, description) in HELP_TOPIC_EMOJIS.items():
-            self.add_option(
-                emoji=emoji,
-                value=emoji,
-                label=label.title(),
-                description=description,
-                default=label=="help needed",
-            )
-
-    async def callback(self, _: Interaction):
-        self.view.value = self.values[0].value  # type: ignore
-        await self.message.edit(content=f"Selected {self.values[0].value}", view=None, delete_after=5)  # type: ignore
 
 class HelpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -341,10 +280,7 @@ class HelpCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        if (
-            message.channel.id == HELP_CHANNEL_ID
-            and message.type is MessageType.thread_created
-        ):
+        if message.channel.id == HELP_CHANNEL_ID and message.type is MessageType.thread_created:
             await message.delete(delay=5)
         if (
             isinstance(message.channel, Thread)
@@ -363,9 +299,7 @@ class HelpCog(commands.Cog):
         if member.id != thread_author.id:
             return
 
-        await close_help_thread(
-            "EVENT [thread_member_remove]", thread, thread_author, self.bot.user
-        )
+        await close_help_thread("EVENT [thread_member_remove]", thread, thread_author, self.bot.user)
 
     @tasks.loop(hours=24)
     async def close_empty_threads(self):
@@ -375,8 +309,7 @@ class HelpCog(commands.Cog):
         active_help_threads = [
             thread
             for thread in await guild.active_threads()
-            if thread.parent_id == HELP_CHANNEL_ID
-            and (not thread.locked and not thread.archived)
+            if thread.parent_id == HELP_CHANNEL_ID and (not thread.locked and not thread.archived)
         ]
 
         thread: Thread
@@ -384,17 +317,12 @@ class HelpCog(commands.Cog):
             thread_created_at = utils.snowflake_time(thread.id)
 
             # We don't want to close it before the wait_for.
-            if (
-                utils.utcnow() - timedelta(seconds=WAIT_FOR_TIMEOUT)
-                <= thread_created_at
-            ):
+            if utils.utcnow() - timedelta(seconds=WAIT_FOR_TIMEOUT) <= thread_created_at:
                 continue
 
             all_messages = [
                 message
-                for message in (
-                    await thread.history(limit=3, oldest_first=True).flatten()
-                )
+                for message in (await thread.history(limit=3, oldest_first=True).flatten())
                 if message.type is MessageType.default
             ]
             # can happen, ignore.
@@ -411,9 +339,7 @@ class HelpCog(commands.Cog):
                     await thread.send(f"<@&{HELPER_ROLE_ID}>", delete_after=5)
                     continue
             else:
-                await close_help_thread(
-                    "TASK [close_empty_threads]", thread, thread_author, self.bot.user
-                )
+                await close_help_thread("TASK [close_empty_threads]", thread, thread_author, self.bot.user)
                 continue
 
     @commands.command()
@@ -429,10 +355,7 @@ class HelpCog(commands.Cog):
 
     @commands.command()
     async def close(self, ctx):
-        if (
-            not isinstance(ctx.channel, Thread)
-            or ctx.channel.parent_id != HELP_CHANNEL_ID
-        ):
+        if not isinstance(ctx.channel, Thread) or ctx.channel.parent_id != HELP_CHANNEL_ID:
             return
 
         thread_author = await get_thread_author(ctx.channel)
@@ -443,32 +366,12 @@ class HelpCog(commands.Cog):
 
     @commands.command()
     @commands.has_role(HELP_MOD_ID)
-    async def topic(self, ctx, *, topic: str):
-        if not (isinstance(ctx.channel, Thread) and ctx.channel.parent.id == HELP_CHANNEL_ID):  # type: ignore
-            return await ctx.send("This command can only be used in help threads!")
-
-        author = match(NAME_TOPIC_REGEX, ctx.channel.name).group("author")  # type: ignore
-        topic_view = TopicEmojiSelectorView(ctx.author.id)
-        topic_view.message = await ctx.send(  # type: ignore
-            f"Select a topic emoji, {ctx.author.id}!",
-            view=topic_view
-        )
-        await topic_view.wait()
-        if not topic_view.value:
-            return
-        topic_emoji = topic_view.value  # type: ignore
-        await ctx.channel.edit(name=f"{topic_emoji} {topic} ({author})")
-
-    @commands.command()
-    @commands.has_role(HELP_MOD_ID)
     async def transfer(self, ctx, *, new_author: Member):
         if not (isinstance(ctx.channel, Thread) and ctx.channel.parent_id == HELP_CHANNEL_ID):  # type: ignore
             return await ctx.send("This command can only be used in help threads!")
 
         topic = match(NAME_TOPIC_REGEX, ctx.channel.name).group("topic")  # type: ignore
-        first_thread_message = (
-            await ctx.channel.history(limit=1, oldest_first=True).flatten()
-        )[0]
+        first_thread_message = (await ctx.channel.history(limit=1, oldest_first=True).flatten())[0]
         old_author = first_thread_message.mentions[0]
 
         await ctx.channel.edit(name=f"{topic} ({new_author})")
@@ -487,6 +390,31 @@ class HelpCog(commands.Cog):
             colour=0x3B88C3,  # Blue
         )
         await ctx.guild.get_channel(HELP_LOGS_CHANNEL_ID).send(embed=embed_log)
+
+    @slash_command(guild_ids=[GUILD_ID])
+    @application_checks_has_role(HELP_MOD_ID)
+    async def topic(
+        self,
+        interaction: Interaction,
+        *,
+        topic: str = SlashOption(
+            description="The thread's topic.",
+        ),
+        emoji: str = SlashOption(
+            description="The emoji to use for the topic.",
+            choices={f"{key} {value}": key for key, value in HELP_TOPIC_EMOJIS.items()},
+        ),
+    ) -> None:
+        """Set the topic of a help thread."""
+        if not (isinstance(interaction.channel, Thread) and interaction.channel.parent.id == HELP_CHANNEL_ID):  # type: ignore # channel can't be None here
+            await interaction.send(
+                f"This command can only be used in channel inherited from <#{HELP_CHANNEL_ID}>", ephemeral=True
+            )
+            return
+
+        author = match(NAME_TOPIC_REGEX, interaction.channel.name).group("author")  # type: ignore # channel and match can't be None
+        await interaction.send(f'Setting the topic to **"{emoji} {topic}"**', ephemeral=True)
+        await interaction.channel.edit(name=f"{emoji} {topic} ({author})")  # type: ignore # channel can't be None here
 
 
 def setup(bot):


### PR DESCRIPTION
This PR massively improves the `=topic` command. 

- It has been converted to a (main guild only) slash command which allows ephemeral responses.
- Made use of Choices to easily select the topic emoji from a predefined list.

Other changes:
- Defined an error handler for application command in this main file to handle slash command errors.
- Handle `commands.MissingRole` in the on_command_error handler.
- Formatted cogs/help.py with black with line length to 120.