### PR TITLE
[help] Overload topic command

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -442,6 +442,7 @@ class HelpCog(commands.Cog):
 
         current_topic, author = previous_values.groups()
         # max channel name length is 100
+        # 5 = "[emoji]< >[topic]< ><(>[author]<)>" + 1 extra space to be sure
         allowed_length = 100 - (len(author) + len(emoji) + 5)
         new_topic = f"{emoji} {topic}"
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -279,7 +279,7 @@ class ThreadCloseView(ui.View):
 class HelpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        #  self.close_empty_threads.start()
+        self.close_empty_threads.start()
         self.bot.loop.create_task(self.create_views())
 
     async def create_views(self):


### PR DESCRIPTION
This PR improves the topic command (again) by doing the following:

- Simple rate limit check that waits 10 seconds after calling the edit method since there is a limit of 2 edits per 10 minutes and the library waits it out, this way can at least tell the user about it instead of doing nothing and assuming the bot doesn't work.
- Check the topic to see if it's even valid
- Compare the current topic to the new one and refuse to set they're the same
- Check the new topic length to avoid errors from discord
- Send a non-ephemeral embedded confirmation in the thread to see who changed it etc

Also formatted `cogs/help.py` with [black](https://black.readthedocs.io/en/stable/) `--line-length 120`

- [x] Did you test it?
