### PR TITLE
feat: add self-assignable roles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ AUTO_THREAD_CHANNEL_ID=...          # Channel in which all messages are automati
 HELP_BANNED_ROLE_ID=...             # THe role that is not allowed to interact with the help channel
 CONSUL_ADDR=...                     # Consul address for the consul database
 CONSUL_TOKEN=...                    # Consul token for the consul database
+UPDATES_ROLE_ID=...                 # The role that is pinged for updates announcements
+NEWS_ROLE_ID=...                    # The role that is pinged for other library/server news

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -29,13 +29,21 @@ class RolesView(View):
         self.add_item(RolesSelect(user=user))
 
 
+class FakeMember(Member):
+    def __init__(self):
+        ...
+
+    def get_role(self, *_):
+        ...
+
+
 class RolesSelect(Select["RolesView"]):
     def __init__(self, *, user: Member | None):
         # this is being invoked to add persistency
         # we only care about custom_id for the store
         # we cannot use guild.me as the bot is not ready so a guild is not available
         if user is None:
-            return super().__init__(custom_id="roles:select")
+            user = FakeMember()
 
         super().__init__(
             custom_id="roles:select",

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -65,8 +65,7 @@ class RolesSelect(Select["RolesView"]):
                 roles.append(Object(role_id))
                 option = get(self.options, value=role)
                 if option is not None:
-                    index = self.options.index(option)
-                    self.options[index].default = True
+                    option.default = True
             elif (
                 interaction.user.get_role(role_id) is not None
                 and role not in self.values
@@ -76,8 +75,7 @@ class RolesSelect(Select["RolesView"]):
                 roles.pop(role_ids.index(role_id))
                 option = get(self.options, value=role)
                 if option is not None:
-                    index = self.options.index(option)
-                    self.options[index].default = False
+                    option.default = False
 
         await interaction.user.edit(roles=roles)
 

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -90,7 +90,7 @@ class RolesSelect(Select["RolesView"]):
         new_roles = [value.capitalize() for value in self.values]
 
         await interaction.edit(
-            content=f"You now have {''.join(new_roles) or 'no roles'}", view=self.view
+            content=f"You now have {', '.join(new_roles) or 'no roles'}", view=self.view
         )
 
 

--- a/cogs/roles.py
+++ b/cogs/roles.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from os import getenv
+from typing import TYPE_CHECKING
+
+from nextcord import Interaction, Member, Object, SelectOption, slash_command
+from nextcord.ext.commands import Cog
+from nextcord.ui import Select, View
+
+if TYPE_CHECKING:
+    from nextcord.abc import Snowflake
+
+
+GUILD_ID = int(getenv("GUILD_ID", 0))
+UPDATES_ROLE_ID = int(getenv("UPDATES_ROLE_ID", 0))
+NEWS_ROLE_ID = int(getenv("NEWS_ROLE_ID", 0))
+
+ROLE_VALUES: dict[str, int] = {
+    "updates": UPDATES_ROLE_ID,
+    "news": NEWS_ROLE_ID,
+}
+
+
+class RolesView(View):
+    def __init__(self, *, user: Member | None):
+        super().__init__(timeout=None)
+
+        self.add_item(RolesSelect(user=user))
+
+
+class RolesSelect(Select["RolesView"]):
+    def __init__(self, *, user: Member | None):
+        # this is being invoked to add persistency
+        # we only care about custom_id for the store
+        # we cannot use guild.me as the bot is not ready so a guild is not available
+        if user is None:
+            return super().__init__(custom_id="roles:select")
+
+        super().__init__(
+            custom_id="roles:select",
+            placeholder="Select your new roles",
+            min_values=0,
+            max_values=2,
+            options=[
+                SelectOption(
+                    label=name.capitalize(),
+                    value=name,
+                    default=user.get_role(role_id) is not None,
+                )
+                for name, role_id in ROLE_VALUES.items()
+            ],
+        )
+
+    async def callback(self, interaction: Interaction):
+        assert isinstance(interaction.user, Member)
+
+        roles: list[Snowflake] = interaction.user.roles  # type: ignore
+        # since list is invariant, it cannot be a union
+        # but apparently Role does not implement Snowflake, this may need a fix
+
+        for role, role_id in ROLE_VALUES.items():
+            if interaction.user.get_role(role_id) is None and role in self.values:
+                # user does not have the role but wants it
+                roles.append(Object(role_id))
+            elif (
+                interaction.user.get_role(role_id) is not None
+                and role not in self.values
+            ):
+                # user has the role but does not want it
+                role_ids = [r.id for r in roles]
+                roles.pop(role_ids.index(role_id))
+
+        await interaction.user.edit(roles=roles)
+
+        new_roles = [value.capitalize() for value in self.values]
+
+        await interaction.edit(content=f"You now have {new_roles}")
+
+
+class Roles(Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+        self.bot.loop.create_task(self.create_views())
+
+    async def create_views(self):
+        if getattr(self.bot, "role_view_set", False) is False:
+            self.bot.add_view(RolesView(user=None))
+            # the view will accept None and only give us a select with a custom_id
+
+            self.bot.role_view_set = True
+
+    @slash_command(guild_ids=[GUILD_ID])
+    async def roles(self, interaction: Interaction):
+        assert isinstance(interaction.user, Member)
+        # this shoud never assert as it cannot be used in guilds
+        # it serves as a way to let the type checker know this is a member
+
+        await interaction.send(
+            "Select your new roles", view=RolesView(user=interaction.user)
+        )
+
+
+def setup(bot):
+    bot.add_cog(Roles(bot))

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from nextcord.ext import commands
 from nextcord.ext.commands import errors
 from nextcord.ext.application_checks import errors as application_errors
 
-bot = commands.Bot("=", intents=Intents(messages=True, guilds=True, members=True))
+bot = commands.Bot("=", intents=Intents(messages=True, guilds=True, members=True, message_content=True))
 bot.load_extension("jishaku")
 
 issue_regex = compile(r"##(\d+)")

--- a/poetry.lock
+++ b/poetry.lock
@@ -105,7 +105,7 @@ python-versions = "*"
 
 [[package]]
 name = "certifi"
-version = "2022.5.18.1"
+version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -135,7 +135,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.5"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
@@ -173,7 +173,7 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.4"
+version = "4.12.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -185,7 +185,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "isort"
@@ -242,7 +242,7 @@ python-versions = "*"
 
 [[package]]
 name = "nextcord"
-version = "2.0.0a10"
+version = "2.0.0rc2"
 description = "A Python wrapper for the Discord API forked from discord.py"
 category = "main"
 optional = false
@@ -278,20 +278,20 @@ test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytes
 
 [[package]]
 name = "requests"
-version = "2.27.1"
+version = "2.28.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7, <4"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
-idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+charset-normalizer = ">=2.0.0,<2.1.0"
+idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
@@ -485,8 +485,8 @@ braceexpand = [
     {file = "braceexpand-0.1.7.tar.gz", hash = "sha256:e6e539bd20eaea53547472ff94f4fb5c3d3bf9d0a89388c4b56663aba765f705"},
 ]
 certifi = [
-    {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},
-    {file = "certifi-2022.5.18.1.tar.gz", hash = "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7"},
+    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
+    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
@@ -497,8 +497,8 @@ click = [
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 frozenlist = [
     {file = "frozenlist-1.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d2257aaba9660f78c7b1d8fea963b68f3feffb1a9d5d05a18401ca9eb3e8d0a3"},
@@ -570,8 +570,8 @@ import-expression = [
     {file = "import_expression-1.1.4.tar.gz", hash = "sha256:06086a6ab3bfa528b1c478e633d6adf2b3a990e31440f6401b0f3ea12b0659a9"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.4-py3-none-any.whl", hash = "sha256:c58c8eb8a762858f49e18436ff552e83914778e50e9d2f1660535ffb364552ec"},
-    {file = "importlib_metadata-4.11.4.tar.gz", hash = "sha256:5d26852efe48c0a32b0509ffbc583fda1a2266545a78d104a6f4aff3db17d700"},
+    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
+    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
 ]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
@@ -650,7 +650,7 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nextcord = [
-    {file = "nextcord-2.0.0a10.tar.gz", hash = "sha256:5126ac396748df07df7c32c2d4dadf060d29f794c35762609228e19b85a58cdf"},
+    {file = "nextcord-2.0.0rc2.tar.gz", hash = "sha256:ed43897227b1d0b221a038858380dca02f4196ad273c928ddfbe6629802b68c6"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
@@ -661,8 +661,8 @@ platformdirs = [
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
 ]
 requests = [
-    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
-    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+    {file = "requests-2.28.0-py3-none-any.whl", hash = "sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f"},
+    {file = "requests-2.28.0.tar.gz", hash = "sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},


### PR DESCRIPTION
This adds a select menu accessible by `/roles` to self-assign roles - currently announcement roles.
These would be easy opt-in roles without the need for a persistent "reaction roles" message to find.
This select adapts to the user's currently obtained roles when invoked, and in the lifetime of the select.
It should be easy to add a new role - mutate `ROLE_VALUES` and add an environment variable to match.
This has been tested to a certain extent but may need more testing on specific cases such as if they got the role without the select updating.
`None` is used in the select and view to denote that this object was created for the only purpose of persistency.
This persistency has been tested over restarts and a timeout never occurs (obviously).
