### PR TITLE
Add 🛠 topic emoji for users using beta versions

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -46,6 +46,7 @@ HELP_TOPIC_EMOJIS: Dict[str, str] = {
     "🤚": "Help Needed",
     "🔥": "Active",
     "⏳": "Stalled",
+    "🛠️": "Development",
     "🐛": "Bug Report",
     "📌": "Pinned",
     "⚠️": "ToS",

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -46,7 +46,7 @@ HELP_TOPIC_EMOJIS: Dict[str, str] = {
     "🤚": "Help Needed",
     "🔥": "Active",
     "⏳": "Stalled",
-    "🛠️": "Development",
+    "🛠️": "Development Version",
     "🐛": "Bug Report",
     "📌": "Pinned",
     "⚠️": "ToS",


### PR DESCRIPTION
Aka installed from the repo 

Not tested or anything, was done on mobile via GitHub but that doesn't matter here.