### PR TITLE
fix: don't mention author when reply

### DIFF
--- a/cogs/docs.py
+++ b/cogs/docs.py
@@ -530,7 +530,7 @@ class Docs(commands.Cog):
         refer = None
         if ref and isinstance(ref.resolved, discord.Message):
             refer = ref.resolved.to_reference()
-        await ctx.send(embed=e, reference=refer)
+        await ctx.send(embed=e, reference=refer, mention_author=False)
 
     @commands.group(name="docs", help="python docs", invoke_without_command=True)
     async def docs_group(self, ctx: commands.Context, *, obj: str = None):


### PR DESCRIPTION
this pr essentially disallows mention author when reply to the `=docs` command
