### PR TITLE
fix(autopaste): Allow users to delete own autopaste message

### DIFF
--- a/cogs/autopaste.py
+++ b/cogs/autopaste.py
@@ -74,10 +74,8 @@ class DeleteMessage(View):
                 return True
             elif thread_author.id == self.message_author.id and thread_author.id == interaction.user.id:
                 return False
-        elif interaction.user.id == self.message_author.id:
-            return True
         
-        return False
+        return interaction.user.id == self.message_author.id
 
 
 class AutoPaste(Cog):


### PR DESCRIPTION
This was an oversight from the previous fix. This fix allows users helping in threads to delete the pasting message for their own messages, as intended before but not the thread author.