### PR TITLE
feat(help): note that server mods must not be mentioned

### DIFF
--- a/cogs/help.py
+++ b/cogs/help.py
@@ -163,6 +163,7 @@ class HelpButton(ui.Button["HelpView"]):
                 "\n\n**Please include the following in your initial message:**"
                 "\n- Relevant code\n- Error (if present)\n- Expected behavior"
                 f"\n\nRefer for more to our help guildlines in <#{HELP_CHANNEL_ID}>"
+                "\n\nPlease do not mention anyone. This includes the Server Moderators."
             ),
         )
         em.set_footer(text="You can close this thread with the button or =close command.")


### PR DESCRIPTION
# Summary

Seeing as people assume that because the Server Mod role is mentionable, then they are allowed to mention the role in help threads. This adds a small note stating that the author is not allowed to mention any member, including the server mods.

(The reason why I specifically stated server mods is because it is currently the only mentionable role in the nextcord guild)