### PR TITLE
refactor(stars): remove versions from star count

### DIFF
--- a/cogs/stars.py
+++ b/cogs/stars.py
@@ -24,8 +24,7 @@ class GitHubStars(commands.Cog):
     async def update_stars(self):
         """Loop to check and update stars"""
         nextcord_stars = await self.get_stars("nextcord/nextcord")
-        nextcord_v3_stars = await self.get_stars("nextcord/nextcord-v3")
-        channel_name = f"v2 {nextcord_stars}🌟| v3 {nextcord_v3_stars}🌟"
+        channel_name = f"v2 {nextcord_stars}🌟"
 
         # update channel name if it has changed
         if self.__channel.name != channel_name:

--- a/cogs/stars.py
+++ b/cogs/stars.py
@@ -24,7 +24,7 @@ class GitHubStars(commands.Cog):
     async def update_stars(self):
         """Loop to check and update stars"""
         nextcord_stars = await self.get_stars("nextcord/nextcord")
-        channel_name = f"v2 {nextcord_stars}🌟"
+        channel_name = f"{nextcord_stars}🌟"
 
         # update channel name if it has changed
         if self.__channel.name != channel_name:


### PR DESCRIPTION
This PR removes the star count for nextcord v3, as the repository has been archived and [discontinued](https://github.com/nextcord/nextcord-v3/commit/857cf44e4be6437843cd8969795eaa2e66285fab).